### PR TITLE
Fix trickplay routing behavior

### DIFF
--- a/crates/jellyswarrm-proxy/src/handlers/common.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/common.rs
@@ -220,6 +220,15 @@ pub async fn process_media_item(
         }
     }
 
+    if let Some(trickplay) = &mut item.trickplay {
+        let mut updated_hash_map = HashMap::new();
+        for (id, v) in trickplay.iter() {
+            let virtual_id = get_virtual_id(id, media_storage, server).await?;
+            updated_hash_map.insert(virtual_id, v.clone());
+        }
+        *trickplay = updated_hash_map;
+    }
+
     item.server_id = server_id.to_string();
 
     Ok(item)

--- a/crates/jellyswarrm-proxy/src/main.rs
+++ b/crates/jellyswarrm-proxy/src/main.rs
@@ -260,6 +260,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .nest(
             "/Videos",
             Router::new()
+                .route("/{stream_id}/Trickplay/{*path}", get(proxy_handler))
                 .route("/{item_id}/stream.mkv", get(handlers::videos::get_mkv))
                 .route("/{item_id}/stream.mp4", get(handlers::videos::get_mkv))
                 .route(

--- a/crates/jellyswarrm-proxy/src/models/jellyfin.rs
+++ b/crates/jellyswarrm-proxy/src/models/jellyfin.rs
@@ -689,7 +689,7 @@ pub struct MediaItem {
     #[serde(rename = "Chapters", skip_serializing_if = "Option::is_none")]
     pub chapters: Option<Vec<Chapter>>,
     #[serde(rename = "Trickplay", skip_serializing_if = "Option::is_none")]
-    pub trickplay: Option<serde_json::Value>,
+    pub trickplay: Option<std::collections::HashMap<String, serde_json::Value>>,
     #[serde(flatten)]
     pub extra: std::collections::HashMap<String, serde_json::Value>,
 }


### PR DESCRIPTION
Maps the media ids in trickplay/mediaitem requests correctly. See #7 