### PR TITLE
remove superfluous v and possible hash from ui_version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,18 +20,18 @@ COPY ui/ ./
 COPY .git/modules/ui/ /app/.git/modules/ui/
 
 # Get and print UI version info
-RUN UI_VERSION=$(git describe --tags) && \
+RUN UI_VERSION=$(git describe --tags --abbrev=0) && \
     UI_COMMIT=$(git rev-parse HEAD) && \
-    echo "UI_VERSION=$UI_VERSION" && \
+    echo "UI_VERSION=${UI_VERSION#v}" && \
     echo "UI_COMMIT=$UI_COMMIT"
 
 # Build production UI bundle
 RUN npm run build:production
 
 # Write ui-version.env file
-RUN UI_VERSION=$(git describe --tags) && \
+RUN UI_VERSION=$(git describe --tags --abbrev=0) && \
     UI_COMMIT=$(git rev-parse HEAD) && \
-    printf "UI_VERSION=%s\nUI_COMMIT=%s\n" "$UI_VERSION" "$UI_COMMIT" > dist/ui-version.env && \
+    printf "UI_VERSION=%s\nUI_COMMIT=%s\n" "${UI_VERSION#v}" "$UI_COMMIT" > dist/ui-version.env && \
     echo "Generated dist/ui-version.env"
 
 


### PR DESCRIPTION
Removing this ensures to have a somewhat sane version. This is expected by jellyfin apps like androidtv and android. #83
