### PR TITLE
Respect subpaths in JellyfinClient

### DIFF
--- a/crates/jellyfin-api/src/client.rs
+++ b/crates/jellyfin-api/src/client.rs
@@ -51,11 +51,11 @@ impl std::hash::Hash for JellyfinClient {
 impl JellyfinClient {
     pub fn new(base_url: &str, client_info: ClientInfo) -> Result<Self, Error> {
         let mut url = Url::parse(base_url)?;
-        // Ensure no trailing slash for consistent joining
-        if url.path().ends_with('/') {
+        // Ensure trailing slash for consistent joining
+        if !url.path().ends_with('/') {
             url.path_segments_mut()
                 .map_err(|_| Error::UrlParse(url::ParseError::EmptyHost))?
-                .pop_if_empty();
+                .push("");
         }
 
         let http_client = Client::builder()

--- a/dev/Caddyfile
+++ b/dev/Caddyfile
@@ -1,0 +1,11 @@
+:80 {
+	handle_path /movies/* {
+		reverse_proxy jellyfin-movies:8096
+	}
+	handle_path /shows/* {
+		reverse_proxy jellyfin-tvshows:8096
+	}
+	handle_path /music/* {
+		reverse_proxy jellyfin-music:8096
+	}
+}

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -131,6 +131,20 @@ services:
       jellyfin-music:
         condition: service_started
 
+  caddy:
+    image: caddy:latest
+    container_name: jellyswarrm-caddy
+    ports:
+      - "8000:80"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+    networks:
+      - jellyfin-dev-net
+    depends_on:
+      - jellyfin-movies
+      - jellyfin-tvshows
+      - jellyfin-music
+
 networks:
   jellyfin-dev-net:
     driver: bridge


### PR DESCRIPTION
Fixes UI showing servers as offline even if the backend actually handles them correctly (See #69)

Also adds subpath routes to the test setup.