### PR TITLE
Fixed search by person

### DIFF
--- a/crates/jellyswarrm-proxy/src/request_preprocessing.rs
+++ b/crates/jellyswarrm-proxy/src/request_preprocessing.rs
@@ -91,6 +91,7 @@ static MEDIA_ID_QUERY_TAGS: &[&str] = &[
     "SeasonId",
     "startItemId",
     "IDs",
+    "PersonIds"
 ];
 
 static USER_ID_PATH_TAGS: &[&str] = &["Users"];

--- a/crates/jellyswarrm-proxy/src/request_preprocessing.rs
+++ b/crates/jellyswarrm-proxy/src/request_preprocessing.rs
@@ -91,7 +91,7 @@ static MEDIA_ID_QUERY_TAGS: &[&str] = &[
     "SeasonId",
     "startItemId",
     "IDs",
-    "PersonIds"
+    "PersonIds",
 ];
 
 static USER_ID_PATH_TAGS: &[&str] = &["Users"];


### PR DESCRIPTION
Just like title says - this fixes items search by persons.

URL:
```
https://host/Users/e28c8016247f45e68df42071de1c50ff/Items?SortOrder=Ascending&IncludeItemTypes=Series&Recursive=true&Fields=ParentId%2CPrimaryImageAspectRatio%2CParentId%2CPrimaryImageAspectRatio&Limit=10&StartIndex=0&CollapseBoxSetItems=false&SortBy=SortName&PersonIds=15cea1cb85d7821b0659afc0960d50a6
```
