### PR TITLE
Allow users to create accounts on Jellyfin instances

### DIFF
--- a/crates/jellyswarrm-proxy/src/ui/mod.rs
+++ b/crates/jellyswarrm-proxy/src/ui/mod.rs
@@ -155,6 +155,10 @@ pub fn ui_routes() -> axum::Router<AppState> {
             "/user/servers/{id}/connect",
             post(user::servers::connect_server),
         )
+        .route(
+            "/user/servers/{id}/create-account",
+            post(user::servers::create_account_on_server),
+        )
         .route("/user/media", get(user::media::get_user_media))
         .route(
             "/user/media/server/{server_id}/libraries",

--- a/crates/jellyswarrm-proxy/src/ui/templates/user/user_server_list.html
+++ b/crates/jellyswarrm-proxy/src/ui/templates/user/user_server_list.html
@@ -91,12 +91,20 @@
                     </span>
                 </td>
                 <td>
-                    <button 
+                    <button
                         onclick="openConnectModal('{{ server.id }}', '{{ server.name }}')"
                         class="contrast outline"
                         style="padding: 0.25rem 0.5rem; font-size: 0.8em;">
                         Connect
                     </button>
+                    {% if federated_server_ids.contains(&server.id) %}
+                    <button
+                        onclick="openCreateAccountModal('{{ server.id }}', '{{ server.name }}')"
+                        class="outline"
+                        style="padding: 0.25rem 0.5rem; font-size: 0.8em;">
+                        Create Account
+                    </button>
+                    {% endif %}
                 </td>
             </tr>
         {% endfor %}
@@ -133,25 +141,73 @@
         </article>
     </dialog>
 
+    <dialog id="create_account_modal">
+        <article>
+            <header>
+                <button aria-label="Close" rel="prev" onclick="closeCreateAccountModal()"></button>
+                <h3>Create Account on <span id="create_modal_server_name"></span></h3>
+            </header>
+            <div id="create_account_error"></div>
+            <form id="create_account_form" method="post" hx-post="" hx-target="#create_account_error" hx-swap="innerHTML">
+                <label>
+                    Username
+                    <input type="text" name="username" required>
+                </label>
+                <label>
+                    Password
+                    {% let pw_input_name = "password" %}
+                    {% let pw_input_placeholder = "Password" %}
+                    {% let pw_input_autocomplete = "new-password" %}
+                    {% let pw_input_required = true %}
+                    {% include "components/password_input.html" %}
+                </label>
+                <footer>
+                    <div class="grid">
+                        <button type="button" class="secondary" onclick="closeCreateAccountModal()">Cancel</button>
+                        <button type="submit">Create Account</button>
+                    </div>
+                </footer>
+            </form>
+        </article>
+    </dialog>
+
     <script>
         (function() {
-            const modal = document.getElementById('connect_modal');
-            const form = document.getElementById('connect_form');
-            const serverNameSpan = document.getElementById('modal_server_name');
-            const errorDiv = document.getElementById('connect_error');
+            const connectModal = document.getElementById('connect_modal');
+            const connectForm = document.getElementById('connect_form');
+            const connectServerNameSpan = document.getElementById('modal_server_name');
+            const connectErrorDiv = document.getElementById('connect_error');
             const uiRoute = "{{ ui_route }}";
 
             window.openConnectModal = function(id, name) {
-                serverNameSpan.innerText = name;
-                form.setAttribute('hx-post', '/' + uiRoute + '/user/servers/' + id + '/connect');
-                htmx.process(form);
-                errorDiv.innerHTML = '';
-                form.reset();
-                modal.showModal();
+                connectServerNameSpan.innerText = name;
+                connectForm.setAttribute('hx-post', '/' + uiRoute + '/user/servers/' + id + '/connect');
+                htmx.process(connectForm);
+                connectErrorDiv.innerHTML = '';
+                connectForm.reset();
+                connectModal.showModal();
             }
 
             window.closeConnectModal = function() {
-                modal.close();
+                connectModal.close();
+            }
+
+            const createModal = document.getElementById('create_account_modal');
+            const createForm = document.getElementById('create_account_form');
+            const createServerNameSpan = document.getElementById('create_modal_server_name');
+            const createErrorDiv = document.getElementById('create_account_error');
+
+            window.openCreateAccountModal = function(id, name) {
+                createServerNameSpan.innerText = name;
+                createForm.setAttribute('hx-post', '/' + uiRoute + '/user/servers/' + id + '/create-account');
+                htmx.process(createForm);
+                createErrorDiv.innerHTML = '';
+                createForm.reset();
+                createModal.showModal();
+            }
+
+            window.closeCreateAccountModal = function() {
+                createModal.close();
             }
         })();
     </script>

--- a/crates/jellyswarrm-proxy/src/ui/user/servers.rs
+++ b/crates/jellyswarrm-proxy/src/ui/user/servers.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use tracing::{error, info};
 
 use crate::{
-    encryption::Password,
+    encryption::{decrypt_password, HashedPassword, Password},
     server_storage::Server,
     ui::{auth::AuthenticatedUser, user::common::authenticate_user_on_server},
     AppState,
@@ -22,11 +22,18 @@ pub struct UserServerListTemplate {
     pub username: String,
     pub servers: Vec<Server>,
     pub unmapped_servers: Vec<Server>,
+    pub federated_server_ids: Vec<i64>,
     pub ui_route: String,
 }
 
 #[derive(Deserialize)]
 pub struct ConnectServerForm {
+    pub username: String,
+    pub password: Password,
+}
+
+#[derive(Deserialize)]
+pub struct CreateAccountForm {
     pub username: String,
     pub password: Password,
 }
@@ -64,10 +71,18 @@ pub async fn get_user_servers(
         .filter(|s| !mapped_servers.iter().any(|ms| ms.id == s.id))
         .collect();
 
+    let mut federated_server_ids = Vec::new();
+    for server in &unmapped_servers {
+        if let Ok(Some(_)) = state.server_storage.get_server_admin(server.id).await {
+            federated_server_ids.push(server.id);
+        }
+    }
+
     let template = UserServerListTemplate {
         username: user.username,
         servers: mapped_servers,
         unmapped_servers,
+        federated_server_ids,
         ui_route: state.get_ui_route().await,
     };
 
@@ -215,6 +230,124 @@ pub async fn connect_server(
                 Html(format!("<div style=\"background-color: #e74c3c; color: white; padding: 0.75rem; border-radius: 0.25rem; margin-bottom: 1rem;\">Connection error: {}</div>", e)),
             )
                 .into_response()
+        }
+    }
+}
+
+pub async fn create_account_on_server(
+    State(state): State<AppState>,
+    AuthenticatedUser(user): AuthenticatedUser,
+    Path(server_id): Path<i64>,
+    Form(form): Form<CreateAccountForm>,
+) -> impl IntoResponse {
+    let error_html = |msg: &str| -> axum::response::Response {
+        (
+            StatusCode::OK,
+            Html(format!(
+                "<div style=\"background-color: #e74c3c; color: white; padding: 0.75rem; border-radius: 0.25rem; margin-bottom: 1rem;\">{}</div>",
+                msg
+            )),
+        )
+            .into_response()
+    };
+
+    // Get server details
+    let server = match state.server_storage.get_server_by_id(server_id).await {
+        Ok(Some(s)) => s,
+        Ok(None) => return error_html("Server not found"),
+        Err(e) => {
+            error!("Failed to get server: {}", e);
+            return error_html("Database error");
+        }
+    };
+
+    // Get admin credentials for this server
+    let admin = match state.server_storage.get_server_admin(server.id).await {
+        Ok(Some(a)) => a,
+        Ok(None) => return error_html("This server does not support account creation"),
+        Err(e) => {
+            error!("Failed to get admin credentials: {}", e);
+            return error_html("Database error");
+        }
+    };
+
+    // Decrypt admin password
+    let config = state.config.read().await;
+    let admin_password: HashedPassword = config.password.clone().into();
+    drop(config);
+
+    let decrypted_admin_password = match decrypt_password(&admin.password, &admin_password) {
+        Ok(p) => p,
+        Err(e) => {
+            error!(
+                "Failed to decrypt admin password for server {}: {}",
+                server.name, e
+            );
+            return error_html("Failed to decrypt admin credentials");
+        }
+    };
+
+    let client_info = crate::config::CLIENT_INFO.clone();
+
+    // Create client and authenticate as admin
+    let client = match JellyfinClient::new(server.url.as_str(), client_info) {
+        Ok(c) => c,
+        Err(e) => {
+            error!("Failed to create jellyfin client: {}", e);
+            return error_html("Client error");
+        }
+    };
+
+    if let Err(e) = client
+        .authenticate_by_name(&admin.username, decrypted_admin_password.as_str())
+        .await
+    {
+        error!(
+            "Failed to authenticate as admin on server {}: {}",
+            server.name, e
+        );
+        return error_html("Admin authentication failed");
+    }
+
+    // Create the user on the Jellyfin server
+    match client
+        .create_user(&form.username, Some(form.password.as_str()))
+        .await
+    {
+        Ok(_new_user) => {
+            // Create local server mapping
+            match state
+                .user_authorization
+                .add_server_mapping(
+                    &user.id,
+                    server.url.as_str(),
+                    &form.username,
+                    &form.password,
+                    Some(&user.password_hash),
+                )
+                .await
+            {
+                Ok(_) => {
+                    info!(
+                        "Created account and mapping for user {} on server {}",
+                        form.username, server.name
+                    );
+                    let mut response = StatusCode::OK.into_response();
+                    response.headers_mut().insert(
+                        "HX-Redirect",
+                        HeaderValue::from_str(&format!("/{}", state.get_ui_route().await)).unwrap(),
+                    );
+                    response
+                }
+                Err(e) => {
+                    error!("Failed to create mapping: {}", e);
+                    error_html("Account created but failed to save mapping")
+                }
+            }
+        }
+        Err(e) => {
+            error!("Failed to create user on server {}: {}", server.name, e);
+            error_html(&format!("Failed to create account: {}", e))
         }
     }
 }

--- a/crates/jellyswarrm-proxy/src/ui/user/servers.rs
+++ b/crates/jellyswarrm-proxy/src/ui/user/servers.rs
@@ -415,6 +415,15 @@ pub async fn delete_server_mapping(
     StatusCode::NOT_FOUND.into_response()
 }
 
+#[allow(dead_code)]
+/// Helper to extract body text from an axum response (used in tests).
+async fn response_body_string(resp: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
 pub async fn check_user_server_status(
     State(state): State<AppState>,
     AuthenticatedUser(user): AuthenticatedUser,
@@ -464,5 +473,323 @@ pub async fn check_user_server_status(
             Html(format!("<span style=\"color: #dc3545;\">{}</span>", e)),
         )
             .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        config::{AppConfig, MediaStreamingMode, MIGRATOR},
+        encryption::encrypt_password,
+        handlers::quick_connect::QuickConnectStorage,
+        media_storage_service::MediaStorageService,
+        processors::{request_analyzer::RequestAnalyzer, request_processor::RequestProcessor},
+        server_storage::ServerStorageService,
+        session_storage::SessionStorage,
+        ui::auth::{User, UserRole},
+        user_authorization_service::UserAuthorizationService,
+        AppState, DataContext, JsonProcessors,
+    };
+    use axum::extract::{Path, State};
+    use axum::Form;
+    use serde_json::json;
+    use sqlx::SqlitePool;
+    use std::sync::Arc;
+    use wiremock::{
+        matchers::{method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
+
+    async fn create_test_app_state() -> AppState {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+
+        let data_context = DataContext {
+            user_authorization: Arc::new(UserAuthorizationService::new(pool.clone())),
+            server_storage: Arc::new(ServerStorageService::new(pool)),
+            media_storage: Arc::new(MediaStorageService::new(
+                SqlitePool::connect("sqlite::memory:").await.unwrap(),
+            )),
+            play_sessions: Arc::new(SessionStorage::new()),
+            config: Arc::new(tokio::sync::RwLock::new(AppConfig::default())),
+        };
+
+        let processors = JsonProcessors {
+            request_processor: RequestProcessor::new(data_context.clone()),
+            request_analyzer: RequestAnalyzer::new(data_context.clone()),
+        };
+
+        AppState::new(
+            reqwest::Client::new(),
+            reqwest::Client::new(),
+            data_context,
+            processors,
+            QuickConnectStorage::new(),
+        )
+    }
+
+    fn make_test_user(id: &str, username: &str) -> User {
+        let password: Password = "test-password".into();
+        User {
+            id: id.to_string(),
+            username: username.to_string(),
+            password_hash: password.into(),
+            role: UserRole::User,
+        }
+    }
+
+    async fn setup_server_with_admin(state: &AppState, upstream_uri: &str) -> i64 {
+        let server_id = state
+            .server_storage
+            .add_server(
+                "TestServer",
+                upstream_uri,
+                100,
+                MediaStreamingMode::Redirect,
+            )
+            .await
+            .unwrap();
+
+        // Encrypt admin password with the default AppConfig password
+        let config = state.config.read().await;
+        let admin_password_hash: crate::encryption::HashedPassword = config.password.clone().into();
+        drop(config);
+
+        let encrypted = encrypt_password(&"admin-pass".into(), &admin_password_hash).unwrap();
+
+        state
+            .server_storage
+            .add_server_admin(server_id, "admin-user", &encrypted)
+            .await
+            .unwrap();
+
+        server_id
+    }
+
+    fn mock_admin_auth() -> Mock {
+        Mock::given(method("POST"))
+            .and(path("/Users/AuthenticateByName"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "AccessToken": "admin-token",
+                "User": {
+                    "Id": "admin-id",
+                    "Name": "admin-user",
+                    "ServerId": "server-1"
+                }
+            })))
+    }
+
+    fn mock_create_user_success() -> Mock {
+        Mock::given(method("POST"))
+            .and(path("/Users/New"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "Id": "new-user-id",
+                "Name": "newuser",
+                "ServerId": "server-1"
+            })))
+    }
+
+    #[tokio::test]
+    async fn create_account_happy_path() {
+        let state = create_test_app_state().await;
+        let upstream = MockServer::start().await;
+
+        mock_admin_auth().mount(&upstream).await;
+        mock_create_user_success().mount(&upstream).await;
+
+        let server_id = setup_server_with_admin(&state, &upstream.uri()).await;
+
+        // Create a Jellyswarrm user
+        let js_user = state
+            .user_authorization
+            .get_or_create_user("TestUser", &"test-password".into())
+            .await
+            .unwrap();
+
+        let user = make_test_user(&js_user.id, "TestUser");
+
+        let resp = create_account_on_server(
+            State(state.clone()),
+            AuthenticatedUser(user),
+            Path(server_id),
+            Form(CreateAccountForm {
+                username: "newuser".to_string(),
+                password: "newpass".into(),
+            }),
+        )
+        .await
+        .into_response();
+
+        // Should redirect on success
+        assert!(resp.headers().contains_key("HX-Redirect"));
+
+        // Verify server mapping was created
+        let mappings = state
+            .user_authorization
+            .list_server_mappings(&js_user.id)
+            .await
+            .unwrap();
+        assert_eq!(mappings.len(), 1);
+        assert_eq!(mappings[0].mapped_username, "newuser");
+    }
+
+    #[tokio::test]
+    async fn create_account_no_admin_credentials() {
+        let state = create_test_app_state().await;
+        let upstream = MockServer::start().await;
+
+        // Add server WITHOUT admin credentials
+        let server_id = state
+            .server_storage
+            .add_server(
+                "NoAdminServer",
+                &upstream.uri(),
+                100,
+                MediaStreamingMode::Redirect,
+            )
+            .await
+            .unwrap();
+
+        let js_user = state
+            .user_authorization
+            .get_or_create_user("TestUser", &"test-password".into())
+            .await
+            .unwrap();
+
+        let user = make_test_user(&js_user.id, "TestUser");
+
+        let resp = create_account_on_server(
+            State(state.clone()),
+            AuthenticatedUser(user),
+            Path(server_id),
+            Form(CreateAccountForm {
+                username: "newuser".to_string(),
+                password: "newpass".into(),
+            }),
+        )
+        .await
+        .into_response();
+
+        assert!(!resp.headers().contains_key("HX-Redirect"));
+        let body = response_body_string(resp).await;
+        assert!(body.contains("does not support account creation"));
+    }
+
+    #[tokio::test]
+    async fn create_account_admin_auth_failure() {
+        let state = create_test_app_state().await;
+        let upstream = MockServer::start().await;
+
+        // Mock admin auth to return 401
+        Mock::given(method("POST"))
+            .and(path("/Users/AuthenticateByName"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&upstream)
+            .await;
+
+        let server_id = setup_server_with_admin(&state, &upstream.uri()).await;
+
+        let js_user = state
+            .user_authorization
+            .get_or_create_user("TestUser", &"test-password".into())
+            .await
+            .unwrap();
+
+        let user = make_test_user(&js_user.id, "TestUser");
+
+        let resp = create_account_on_server(
+            State(state.clone()),
+            AuthenticatedUser(user),
+            Path(server_id),
+            Form(CreateAccountForm {
+                username: "newuser".to_string(),
+                password: "newpass".into(),
+            }),
+        )
+        .await
+        .into_response();
+
+        assert!(!resp.headers().contains_key("HX-Redirect"));
+        let body = response_body_string(resp).await;
+        assert!(body.contains("Admin authentication failed"));
+    }
+
+    #[tokio::test]
+    async fn create_account_user_creation_failure() {
+        let state = create_test_app_state().await;
+        let upstream = MockServer::start().await;
+
+        mock_admin_auth().mount(&upstream).await;
+
+        // Mock user creation to fail (e.g., username already taken)
+        Mock::given(method("POST"))
+            .and(path("/Users/New"))
+            .respond_with(ResponseTemplate::new(400).set_body_string("Username already exists"))
+            .mount(&upstream)
+            .await;
+
+        let server_id = setup_server_with_admin(&state, &upstream.uri()).await;
+
+        let js_user = state
+            .user_authorization
+            .get_or_create_user("TestUser", &"test-password".into())
+            .await
+            .unwrap();
+
+        let user = make_test_user(&js_user.id, "TestUser");
+
+        let resp = create_account_on_server(
+            State(state.clone()),
+            AuthenticatedUser(user),
+            Path(server_id),
+            Form(CreateAccountForm {
+                username: "newuser".to_string(),
+                password: "newpass".into(),
+            }),
+        )
+        .await
+        .into_response();
+
+        assert!(!resp.headers().contains_key("HX-Redirect"));
+        let body = response_body_string(resp).await;
+        assert!(body.contains("Failed to create account"));
+
+        // Verify no mapping was created
+        let mappings = state
+            .user_authorization
+            .list_server_mappings(&js_user.id)
+            .await
+            .unwrap();
+        assert!(mappings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_account_nonexistent_server() {
+        let state = create_test_app_state().await;
+
+        let js_user = state
+            .user_authorization
+            .get_or_create_user("TestUser", &"test-password".into())
+            .await
+            .unwrap();
+
+        let user = make_test_user(&js_user.id, "TestUser");
+
+        let resp = create_account_on_server(
+            State(state.clone()),
+            AuthenticatedUser(user),
+            Path(9999), // Non-existent server ID
+            Form(CreateAccountForm {
+                username: "newuser".to_string(),
+                password: "newpass".into(),
+            }),
+        )
+        .await
+        .into_response();
+
+        assert!(!resp.headers().contains_key("HX-Redirect"));
+        let body = response_body_string(resp).await;
+        assert!(body.contains("Server not found"));
     }
 }


### PR DESCRIPTION
Lets users create accounts on unlinked Jellyfin instances directly from the server list.

Unfortunately vibe coded, as I wanted this feature quickly.

Partially closes #44 