### PR TITLE
Harden server url handling and session management

### DIFF
--- a/crates/jellyswarrm-proxy/migrations/20260508120000_server_id_identity.down.sql
+++ b/crates/jellyswarrm-proxy/migrations/20260508120000_server_id_identity.down.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS idx_servers_url_unique;
+
+DROP INDEX IF EXISTS idx_media_mappings_server_id;
+DROP INDEX IF EXISTS idx_media_mappings_original_server_id;
+ALTER TABLE media_mappings DROP COLUMN server_id;
+
+DROP INDEX IF EXISTS idx_server_mappings_server_id;
+DROP INDEX IF EXISTS idx_server_mappings_user_server_id;
+ALTER TABLE server_mappings DROP COLUMN server_id;

--- a/crates/jellyswarrm-proxy/migrations/20260508120000_server_id_identity.up.sql
+++ b/crates/jellyswarrm-proxy/migrations/20260508120000_server_id_identity.up.sql
@@ -1,0 +1,122 @@
+UPDATE servers
+SET url = RTRIM(TRIM(url), '/');
+
+DELETE FROM server_admins
+WHERE id NOT IN (
+    SELECT MIN(server_admins.id)
+    FROM server_admins
+    JOIN servers ON servers.id = server_admins.server_id
+    GROUP BY servers.url
+);
+
+UPDATE server_admins
+SET server_id = (
+    SELECT MIN(canonical_servers.id)
+    FROM servers AS canonical_servers
+    JOIN servers AS current_server ON canonical_servers.url = current_server.url
+    WHERE current_server.id = server_admins.server_id
+);
+
+DELETE FROM servers
+WHERE id NOT IN (
+    SELECT MIN(id)
+    FROM servers
+    GROUP BY url
+);
+
+CREATE UNIQUE INDEX idx_servers_url_unique
+    ON servers(RTRIM(TRIM(url), '/'));
+
+ALTER TABLE server_mappings ADD COLUMN server_id INTEGER REFERENCES servers(id) ON DELETE CASCADE;
+
+UPDATE server_mappings
+SET server_id = (
+    SELECT servers.id
+    FROM servers
+    WHERE RTRIM(servers.url, '/') = RTRIM(server_mappings.server_url, '/')
+    ORDER BY servers.id ASC
+    LIMIT 1
+)
+WHERE server_id IS NULL;
+
+DELETE FROM authorization_sessions
+WHERE mapping_id IN (
+    SELECT id
+    FROM server_mappings
+    WHERE server_id IS NULL
+);
+
+DELETE FROM server_mappings
+WHERE server_id IS NULL;
+
+DELETE FROM authorization_sessions
+WHERE id IN (
+    SELECT id
+    FROM (
+        SELECT
+            auth.id,
+            ROW_NUMBER() OVER (
+                PARTITION BY auth.user_id, mapping.user_id, mapping.server_id, auth.device_id
+                ORDER BY auth.updated_at DESC, auth.created_at DESC, auth.id DESC
+            ) AS duplicate_rank
+        FROM authorization_sessions AS auth
+        JOIN server_mappings AS mapping
+            ON mapping.id = auth.mapping_id
+    ) AS ranked_sessions
+    WHERE duplicate_rank > 1
+);
+
+UPDATE authorization_sessions
+SET mapping_id = (
+    SELECT MIN(canonical_mapping.id)
+    FROM server_mappings AS current_mapping
+    JOIN server_mappings AS canonical_mapping
+        ON canonical_mapping.user_id = current_mapping.user_id
+        AND canonical_mapping.server_id = current_mapping.server_id
+    WHERE current_mapping.id = authorization_sessions.mapping_id
+)
+WHERE mapping_id IN (
+    SELECT id
+    FROM server_mappings
+);
+
+DELETE FROM server_mappings
+WHERE id NOT IN (
+    SELECT MIN(id)
+    FROM server_mappings
+    GROUP BY user_id, server_id
+);
+
+CREATE UNIQUE INDEX idx_server_mappings_user_server_id
+    ON server_mappings(user_id, server_id);
+
+CREATE INDEX idx_server_mappings_server_id
+    ON server_mappings(server_id);
+
+ALTER TABLE media_mappings ADD COLUMN server_id INTEGER REFERENCES servers(id) ON DELETE CASCADE;
+
+UPDATE media_mappings
+SET server_id = (
+    SELECT servers.id
+    FROM servers
+    WHERE RTRIM(servers.url, '/') = RTRIM(media_mappings.server_url, '/')
+    ORDER BY servers.id ASC
+    LIMIT 1
+)
+WHERE server_id IS NULL;
+
+DELETE FROM media_mappings
+WHERE server_id IS NULL;
+
+DELETE FROM media_mappings
+WHERE id NOT IN (
+    SELECT MIN(id)
+    FROM media_mappings
+    GROUP BY original_media_id, server_id
+);
+
+CREATE UNIQUE INDEX idx_media_mappings_original_server_id
+    ON media_mappings(original_media_id, server_id);
+
+CREATE INDEX idx_media_mappings_server_id
+    ON media_mappings(server_id);

--- a/crates/jellyswarrm-proxy/src/federated_users.rs
+++ b/crates/jellyswarrm-proxy/src/federated_users.rs
@@ -188,7 +188,7 @@ impl FederatedUserService {
                             .user_authorization
                             .add_server_mapping(
                                 user_id,
-                                server.url.as_str(),
+                                &server,
                                 username,
                                 password,
                                 Some(&password.into()), // Encrypt with their own password so they can use it
@@ -231,7 +231,7 @@ impl FederatedUserService {
                                 .user_authorization
                                 .add_server_mapping(
                                     user_id,
-                                    server.url.as_str(),
+                                    &server,
                                     username,
                                     password,
                                     Some(&password.into()), // Encrypt with their own password so they can use it

--- a/crates/jellyswarrm-proxy/src/handlers/common.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/common.rs
@@ -383,7 +383,7 @@ pub async fn track_play_session(
             .add_session(PlaybackSession {
                 item_id: id.to_string(),
                 session_id: session_id.to_string(),
-                server: server.clone(),
+                server_id: server.id,
             })
             .await;
     } else {
@@ -397,7 +397,7 @@ pub async fn track_play_session(
             .add_session(PlaybackSession {
                 item_id: item.id.clone(),
                 session_id: session_id.to_string(),
-                server: server.clone(),
+                server_id: server.id,
             })
             .await;
     }

--- a/crates/jellyswarrm-proxy/src/handlers/common.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/common.rs
@@ -364,6 +364,7 @@ pub async fn process_media_source(
 pub async fn track_play_session(
     item: &MediaSource,
     session_id: &str,
+    user_id: &str,
     server: &Server,
     state: &AppState,
 ) -> Result<(), StatusCode> {
@@ -383,6 +384,7 @@ pub async fn track_play_session(
             .add_session(PlaybackSession {
                 item_id: id.to_string(),
                 session_id: session_id.to_string(),
+                user_id: user_id.to_string(),
                 server_id: server.id,
             })
             .await;
@@ -397,6 +399,7 @@ pub async fn track_play_session(
             .add_session(PlaybackSession {
                 item_id: item.id.clone(),
                 session_id: session_id.to_string(),
+                user_id: user_id.to_string(),
                 server_id: server.id,
             })
             .await;

--- a/crates/jellyswarrm-proxy/src/handlers/common.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/common.rs
@@ -167,7 +167,7 @@ pub async fn get_virtual_id(
     server: &Server,
 ) -> Result<String, StatusCode> {
     let mapping = media_storage
-        .get_or_create_media_mapping(id, server.url.as_str())
+        .get_or_create_media_mapping(id, server)
         .await
         .map_err(|e| {
             error!(

--- a/crates/jellyswarrm-proxy/src/handlers/items.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/items.rs
@@ -169,7 +169,14 @@ pub async fn post_playback_info(
         Ok(mut response) => {
             for item in &mut response.media_sources {
                 *item = process_media_source(item.clone(), &state.media_storage, &server).await?;
-                track_play_session(item, &response.play_session_id, &server, &state).await?;
+                track_play_session(
+                    item,
+                    &response.play_session_id,
+                    &session.user_id,
+                    &server,
+                    &state,
+                )
+                .await?;
             }
 
             debug!("Requested Playback: {:?}", response);

--- a/crates/jellyswarrm-proxy/src/handlers/livestreams.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/livestreams.rs
@@ -61,7 +61,14 @@ pub async fn post_livestream_open(
         Ok(mut response) => {
             for item in &mut response.media_sources {
                 *item = process_media_source(item.clone(), &state.media_storage, &server).await?;
-                track_play_session(item, &response.play_session_id, &server, &state).await?;
+                track_play_session(
+                    item,
+                    &response.play_session_id,
+                    &session.user_id,
+                    &server,
+                    &state,
+                )
+                .await?;
             }
 
             debug!("Requested Playback: {:?}", response);

--- a/crates/jellyswarrm-proxy/src/handlers/quick_connect.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/quick_connect.rs
@@ -498,9 +498,10 @@ pub async fn handle_authenticate_with_quick_connect(
     let authorization = effective_quick_connect_authorization(&headers, &session, &user.id);
 
     for server_mapping in server_mappings {
-        if let Some(pos) = servers.iter().position(|s| {
-            s.url.as_str().trim_end_matches('/') == server_mapping.server_url.trim_end_matches('/')
-        }) {
+        if let Some(pos) = servers
+            .iter()
+            .position(|s| s.id == server_mapping.server_id)
+        {
             let server = servers.remove(pos);
             let state = state.clone();
             let authorization = authorization.clone();
@@ -518,8 +519,8 @@ pub async fn handle_authenticate_with_quick_connect(
             }));
         } else {
             debug!(
-                "Skipping mapping for unknown server URL {}",
-                server_mapping.server_url
+                "Skipping mapping for unknown server ID {}",
+                server_mapping.server_id
             );
         }
     }
@@ -606,7 +607,7 @@ async fn authenticate_with_mapping_on_server(
         .user_authorization
         .add_server_mapping(
             &user.id,
-            server.url.as_str(),
+            &server,
             &server_mapping.mapped_username,
             &mapped_password,
             Some(&user.original_password_hash),
@@ -637,7 +638,7 @@ async fn authenticate_with_mapping_on_server(
         .user_authorization
         .store_authorization_session(
             &user.id,
-            server.url.as_str(),
+            &server,
             &auth_to_store,
             auth_token,
             original_user_id,
@@ -898,10 +899,16 @@ mod tests {
             .mount(&upstream)
             .await;
 
-        state
+        let upstream_server_id = state
             .server_storage
             .add_server("Upstream", &upstream.uri(), 100, MediaStreamingMode::Proxy)
             .await
+            .unwrap();
+        let upstream_server = state
+            .server_storage
+            .get_server_by_id(upstream_server_id)
+            .await
+            .unwrap()
             .unwrap();
 
         let user = state
@@ -914,7 +921,7 @@ mod tests {
             .user_authorization
             .add_server_mapping(
                 &user.id,
-                &upstream.uri(),
+                &upstream_server,
                 "mappeduser",
                 &"mappedpass".into(),
                 None,
@@ -934,7 +941,7 @@ mod tests {
             .user_authorization
             .store_authorization_session(
                 &user.id,
-                &upstream.uri(),
+                &upstream_server,
                 &existing_web_auth,
                 "web-upstream-token".to_string(),
                 "upstream-user-id".to_string(),

--- a/crates/jellyswarrm-proxy/src/handlers/syncplay/routes.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/syncplay/routes.rs
@@ -18,7 +18,9 @@ use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
-use crate::{request_preprocessing::resolve_request_identity_from_headers_uri, AppState};
+use crate::{
+    request_preprocessing::resolve_request_identity_from_headers_uri, server_id::ServerId, AppState,
+};
 
 use super::models::*;
 use super::service::SessionContext;
@@ -117,10 +119,6 @@ fn user_id_from_session_id(session_id: &str) -> Option<&str> {
     session_id.split(':').next().filter(|s| !s.is_empty())
 }
 
-fn normalize_server_url(input: &str) -> &str {
-    input.trim_end_matches('/')
-}
-
 async fn users_have_library_access_to_items(
     state: &AppState,
     user_ids: &[String],
@@ -130,9 +128,9 @@ async fn users_have_library_access_to_items(
         return Ok(true);
     }
 
-    let mut user_server_urls: HashMap<String, HashSet<String>> = HashMap::new();
+    let mut user_server_ids: HashMap<String, HashSet<ServerId>> = HashMap::new();
     for user_id in user_ids {
-        if user_server_urls.contains_key(user_id) {
+        if user_server_ids.contains_key(user_id) {
             continue;
         }
 
@@ -146,11 +144,11 @@ async fn users_have_library_access_to_items(
             return Ok(false);
         };
 
-        let urls = sessions
+        let server_ids = sessions
             .into_iter()
-            .map(|(auth_session, _)| normalize_server_url(&auth_session.server_url).to_string())
+            .map(|(_, server)| server.id)
             .collect::<HashSet<_>>();
-        user_server_urls.insert(user_id.clone(), urls);
+        user_server_ids.insert(user_id.clone(), server_ids);
     }
 
     for item_id in item_ids {
@@ -163,9 +161,8 @@ async fn users_have_library_access_to_items(
             return Ok(false);
         };
 
-        let needed_server = normalize_server_url(&mapping.server_url);
-        for urls in user_server_urls.values() {
-            if !urls.contains(needed_server) {
+        for server_ids in user_server_ids.values() {
+            if !server_ids.contains(&mapping.server_id) {
                 return Ok(false);
             }
         }

--- a/crates/jellyswarrm-proxy/src/handlers/users.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/users.rs
@@ -164,10 +164,10 @@ pub async fn handle_authenticate_by_name(
 
         if !server_mappings.is_empty() {
             for server_mapping in server_mappings {
-                if let Some(pos) = servers.iter().position(|s| {
-                    s.url.as_str().trim_end_matches('/')
-                        == server_mapping.server_url.trim_end_matches('/')
-                }) {
+                if let Some(pos) = servers
+                    .iter()
+                    .position(|s| s.id == server_mapping.server_id)
+                {
                     let server = servers.remove(pos);
                     info!(
                         "Using server mapping for user '{}' on server '{}'",
@@ -301,7 +301,7 @@ async fn persist_successful_auths(
             .user_authorization
             .add_server_mapping(
                 &user.id,
-                successful.server.url.as_str(),
+                &successful.server,
                 &successful.final_username,
                 &successful.final_password,
                 Some(&login_password.clone().into()),
@@ -319,7 +319,7 @@ async fn persist_successful_auths(
             .user_authorization
             .store_authorization_session(
                 &user.id,
-                successful.server.url.as_str(),
+                &successful.server,
                 &auth_to_store,
                 successful.auth_response.access_token.clone(),
                 successful.auth_response.user.id.clone(),

--- a/crates/jellyswarrm-proxy/src/handlers/videos.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/videos.rs
@@ -4,12 +4,13 @@ use axum::http::{HeaderMap, HeaderName};
 use axum::response::{IntoResponse, Response};
 use futures_util::StreamExt;
 use hyper::StatusCode;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::{
     config::MediaStreamingMode,
     request_preprocessing::{apply_to_request, preprocess_request, remap_authorization},
     server_storage::Server,
+    session_storage::PlaybackSession,
     user_authorization_service::AuthorizationSession,
     AppState,
 };
@@ -43,6 +44,20 @@ fn extract_play_session_id(url: &url::Url) -> Option<String> {
             .then(|| value.to_string())
             .filter(|value| !value.is_empty())
     })
+}
+
+fn single_matching_play_session(
+    mut candidates: Vec<PlaybackSession>,
+    user_id: Option<&str>,
+) -> Result<PlaybackSession, usize> {
+    if let Some(user_id) = user_id {
+        candidates.retain(|session| session.user_id == user_id);
+    }
+
+    match candidates.len() {
+        1 => Ok(candidates.remove(0)),
+        count => Err(count),
+    }
 }
 
 async fn proxy_request(
@@ -105,22 +120,56 @@ pub async fn get_video_resource(
         .ok_or(StatusCode::BAD_REQUEST)?;
 
     let id = extract_video_id(original_request.url().path()).ok_or(StatusCode::NOT_FOUND)?;
-    let play_session_id = extract_play_session_id(original_request.url()).ok_or_else(|| {
-        error!("No play session id found for video resource: {}", id);
-        StatusCode::NOT_FOUND
-    })?;
+    let play_session_id = extract_play_session_id(original_request.url());
+    let play_session = if let Some(play_session_id) = play_session_id.as_deref() {
+        state
+            .play_sessions
+            .get_session_by_session_and_item_id(play_session_id, id)
+            .await
+            .ok_or_else(|| {
+                error!(
+                    "No play session found for resource: {} and session: {}",
+                    id, play_session_id
+                );
+                StatusCode::NOT_FOUND
+            })?
+    } else {
+        let candidates = state.play_sessions.get_sessions_by_item_id(id).await;
+        let user_id = preprocessed
+            .user
+            .as_ref()
+            .map(|user| user.id.as_str())
+            .or_else(|| {
+                preprocessed
+                    .session
+                    .as_ref()
+                    .map(|session| session.user_id.as_str())
+            });
 
-    let play_session = state
-        .play_sessions
-        .get_session_by_session_and_item_id(&play_session_id, id)
-        .await
-        .ok_or_else(|| {
-            error!(
-                "No play session found for resource: {} and session: {}",
-                id, play_session_id
-            );
-            StatusCode::NOT_FOUND
-        })?;
+        match single_matching_play_session(candidates, user_id) {
+            Ok(play_session) => {
+                warn!(
+                    "Video resource {} arrived without play session id; using only matching active session {}",
+                    id, play_session.session_id
+                );
+                play_session
+            }
+            Err(0) => {
+                error!(
+                    "No play session found for video resource without session id: {}",
+                    id
+                );
+                return Err(StatusCode::NOT_FOUND);
+            }
+            Err(count) => {
+                error!(
+                    "Ambiguous video resource {} without play session id matched {} active sessions",
+                    id, count
+                );
+                return Err(StatusCode::NOT_FOUND);
+            }
+        }
+    };
 
     let server = match state
         .server_storage
@@ -129,7 +178,7 @@ pub async fn get_video_resource(
         .map_err(|e| {
             error!(
                 "Failed to resolve server {} for play session {}: {}",
-                play_session.server_id, play_session_id, e
+                play_session.server_id, play_session.session_id, e
             );
             StatusCode::INTERNAL_SERVER_ERROR
         })? {
@@ -141,7 +190,7 @@ pub async fn get_video_resource(
                 .await;
             error!(
                 "Server {} for play session {} no longer exists",
-                play_session.server_id, play_session_id
+                play_session.server_id, play_session.session_id
             );
             return Err(StatusCode::NOT_FOUND);
         }
@@ -155,14 +204,14 @@ pub async fn get_video_resource(
     {
         error!(
             "Server {} for play session {} is not healthy",
-            server.name, play_session_id
+            server.name, play_session.session_id
         );
         return Err(StatusCode::NOT_FOUND);
     }
 
     info!(
         "Found play session for resource: {}, session: {}, server: {}",
-        id, play_session_id, server.name
+        id, play_session.session_id, server.name
     );
 
     let mut upstream_request = original_request;
@@ -216,5 +265,70 @@ pub async fn get_stream(
             info!("Proxying MKV stream from: {}", url);
             proxy_request(&state.streaming_reqwest_client, request).await
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server_id::ServerId;
+
+    fn playback_session(session_id: &str, user_id: &str, server_id: i64) -> PlaybackSession {
+        PlaybackSession {
+            session_id: session_id.to_string(),
+            item_id: "item-1".to_string(),
+            user_id: user_id.to_string(),
+            server_id: ServerId::new(server_id),
+        }
+    }
+
+    #[test]
+    fn single_matching_play_session_accepts_one_candidate() {
+        let session = single_matching_play_session(
+            vec![playback_session("session-1", "user-1", 1)],
+            Some("user-1"),
+        )
+        .unwrap();
+
+        assert_eq!(session.session_id, "session-1");
+        assert_eq!(session.server_id, ServerId::new(1));
+    }
+
+    #[test]
+    fn single_matching_play_session_filters_by_user() {
+        let session = single_matching_play_session(
+            vec![
+                playback_session("session-1", "user-1", 1),
+                playback_session("session-2", "user-2", 2),
+            ],
+            Some("user-2"),
+        )
+        .unwrap();
+
+        assert_eq!(session.session_id, "session-2");
+        assert_eq!(session.server_id, ServerId::new(2));
+    }
+
+    #[test]
+    fn single_matching_play_session_rejects_ambiguous_matches() {
+        let result = single_matching_play_session(
+            vec![
+                playback_session("session-1", "user-1", 1),
+                playback_session("session-2", "user-1", 2),
+            ],
+            Some("user-1"),
+        );
+
+        assert!(matches!(result, Err(2)));
+    }
+
+    #[test]
+    fn single_matching_play_session_rejects_missing_user_match() {
+        let result = single_matching_play_session(
+            vec![playback_session("session-1", "user-1", 1)],
+            Some("user-2"),
+        );
+
+        assert!(matches!(result, Err(0)));
     }
 }

--- a/crates/jellyswarrm-proxy/src/handlers/videos.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/videos.rs
@@ -69,10 +69,6 @@ async fn proxy_request(
     Ok(response)
 }
 
-fn session_matches_server(session: &AuthorizationSession, server: &Server) -> bool {
-    session.server_url.trim_end_matches('/') == server.url.as_str().trim_end_matches('/')
-}
-
 fn session_for_server(
     sessions: &Option<Vec<(AuthorizationSession, Server)>>,
     server: &Server,
@@ -80,7 +76,7 @@ fn session_for_server(
     sessions.as_ref().and_then(|sessions| {
         sessions
             .iter()
-            .find(|(session, _)| session_matches_server(session, server))
+            .find(|(_, session_server)| session_server.id == server.id)
             .map(|(session, _)| session.clone())
     })
 }
@@ -115,10 +111,9 @@ pub async fn get_video_resource(
 
     let mut upstream_request = original_request;
     let session = session_for_server(&preprocessed.sessions, &server).or_else(|| {
-        preprocessed
-            .session
-            .clone()
-            .filter(|session| session_matches_server(session, &server))
+        (preprocessed.server.id == server.id)
+            .then(|| preprocessed.session.clone())
+            .flatten()
     });
     let new_auth = remap_authorization(&preprocessed.auth, &session)
         .await

--- a/crates/jellyswarrm-proxy/src/handlers/videos.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/videos.rs
@@ -37,6 +37,14 @@ fn extract_video_id(path: &str) -> Option<&str> {
     None
 }
 
+fn extract_play_session_id(url: &url::Url) -> Option<String> {
+    url.query_pairs().find_map(|(key, value)| {
+        (key.eq_ignore_ascii_case("PlaySessionId") || key.eq_ignore_ascii_case("SessionId"))
+            .then(|| value.to_string())
+            .filter(|value| !value.is_empty())
+    })
+}
+
 async fn proxy_request(
     client: &reqwest::Client,
     request: reqwest::Request,
@@ -97,17 +105,65 @@ pub async fn get_video_resource(
         .ok_or(StatusCode::BAD_REQUEST)?;
 
     let id = extract_video_id(original_request.url().path()).ok_or(StatusCode::NOT_FOUND)?;
+    let play_session_id = extract_play_session_id(original_request.url()).ok_or_else(|| {
+        error!("No play session id found for video resource: {}", id);
+        StatusCode::NOT_FOUND
+    })?;
 
-    let server = if let Some(session) = state.play_sessions.get_session_by_item_id(id).await {
-        info!(
-            "Found play session for resource: {}, server: {}",
-            id, session.server.name
-        );
-        session.server
-    } else {
-        error!("No play session found for resource: {}", id);
-        return Err(StatusCode::NOT_FOUND);
+    let play_session = state
+        .play_sessions
+        .get_session_by_session_and_item_id(&play_session_id, id)
+        .await
+        .ok_or_else(|| {
+            error!(
+                "No play session found for resource: {} and session: {}",
+                id, play_session_id
+            );
+            StatusCode::NOT_FOUND
+        })?;
+
+    let server = match state
+        .server_storage
+        .get_server_by_id(play_session.server_id)
+        .await
+        .map_err(|e| {
+            error!(
+                "Failed to resolve server {} for play session {}: {}",
+                play_session.server_id, play_session_id, e
+            );
+            StatusCode::INTERNAL_SERVER_ERROR
+        })? {
+        Some(server) => server,
+        None => {
+            state
+                .play_sessions
+                .remove_sessions_for_server(play_session.server_id)
+                .await;
+            error!(
+                "Server {} for play session {} no longer exists",
+                play_session.server_id, play_session_id
+            );
+            return Err(StatusCode::NOT_FOUND);
+        }
     };
+
+    if !state
+        .server_storage
+        .server_status(server.id)
+        .await
+        .is_healthy()
+    {
+        error!(
+            "Server {} for play session {} is not healthy",
+            server.name, play_session_id
+        );
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    info!(
+        "Found play session for resource: {}, session: {}, server: {}",
+        id, play_session_id, server.name
+    );
 
     let mut upstream_request = original_request;
     let session = session_for_server(&preprocessed.sessions, &server).or_else(|| {

--- a/crates/jellyswarrm-proxy/src/legacy_server_identity.rs
+++ b/crates/jellyswarrm-proxy/src/legacy_server_identity.rs
@@ -1,0 +1,710 @@
+use std::collections::HashMap;
+
+use anyhow::{anyhow, Context, Result};
+use sqlx::{Row, Sqlite, SqlitePool, Transaction};
+
+use crate::server_url::ServerUrl;
+
+#[derive(Debug, Clone)]
+struct LegacyServer {
+    id: i64,
+    canonical_url: String,
+}
+
+#[derive(Debug)]
+struct LegacyMapping {
+    id: i64,
+    server_id: Option<i64>,
+    server_url: String,
+}
+
+#[derive(Debug)]
+struct LegacyMediaMapping {
+    id: i64,
+    server_id: Option<i64>,
+    server_url: String,
+}
+
+pub async fn canonicalize_legacy_server_identity(pool: &SqlitePool) -> Result<()> {
+    let mut tx = pool.begin().await?;
+
+    if !table_exists(&mut tx, "servers").await? {
+        tx.commit().await?;
+        return Ok(());
+    }
+
+    let servers = load_servers(&mut tx).await?;
+    if servers.is_empty() {
+        tx.commit().await?;
+        return Ok(());
+    }
+
+    let canonical_server_ids = canonical_server_ids(&servers);
+    let canonical_server_urls = canonical_server_urls(&servers);
+
+    if table_exists(&mut tx, "server_admins").await? {
+        merge_server_admins(&mut tx, &canonical_server_ids).await?;
+    }
+
+    if table_exists(&mut tx, "server_mappings").await? {
+        let has_server_id = column_exists(&mut tx, "server_mappings", "server_id").await?;
+        canonicalize_server_mappings(
+            &mut tx,
+            has_server_id,
+            &canonical_server_ids,
+            &canonical_server_urls,
+        )
+        .await?;
+    }
+
+    if table_exists(&mut tx, "media_mappings").await? {
+        let has_server_id = column_exists(&mut tx, "media_mappings", "server_id").await?;
+        canonicalize_media_mappings(
+            &mut tx,
+            has_server_id,
+            &canonical_server_ids,
+            &canonical_server_urls,
+        )
+        .await?;
+    }
+
+    if table_exists(&mut tx, "authorization_sessions").await?
+        && table_exists(&mut tx, "server_mappings").await?
+    {
+        sqlx::query(
+            r#"
+            UPDATE authorization_sessions
+            SET server_url = (
+                SELECT server_mappings.server_url
+                FROM server_mappings
+                WHERE server_mappings.id = authorization_sessions.mapping_id
+            )
+            WHERE EXISTS (
+                SELECT 1
+                FROM server_mappings
+                WHERE server_mappings.id = authorization_sessions.mapping_id
+            )
+            "#,
+        )
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    merge_servers(&mut tx, &servers).await?;
+
+    tx.commit().await?;
+    Ok(())
+}
+
+async fn table_exists(tx: &mut Transaction<'_, Sqlite>, table: &str) -> Result<bool> {
+    let count = sqlx::query_scalar::<_, i64>(
+        r#"
+        SELECT COUNT(*)
+        FROM sqlite_master
+        WHERE type = 'table' AND name = ?
+        "#,
+    )
+    .bind(table)
+    .fetch_one(&mut **tx)
+    .await?;
+
+    Ok(count > 0)
+}
+
+async fn column_exists(
+    tx: &mut Transaction<'_, Sqlite>,
+    table: &str,
+    column: &str,
+) -> Result<bool> {
+    let query = format!("SELECT COUNT(*) FROM pragma_table_info('{table}') WHERE name = ?");
+    let count = sqlx::query_scalar::<_, i64>(&query)
+        .bind(column)
+        .fetch_one(&mut **tx)
+        .await?;
+
+    Ok(count > 0)
+}
+
+async fn load_servers(tx: &mut Transaction<'_, Sqlite>) -> Result<Vec<LegacyServer>> {
+    let rows = sqlx::query("SELECT id, url FROM servers ORDER BY id ASC")
+        .fetch_all(&mut **tx)
+        .await?;
+
+    rows.into_iter()
+        .map(|row| {
+            let id = row.get("id");
+            let url: String = row.get("url");
+            let canonical_url = ServerUrl::canonicalize(&url).with_context(|| {
+                format!("Invalid server URL in database for server id {id}: {url}")
+            })?;
+
+            Ok(LegacyServer { id, canonical_url })
+        })
+        .collect()
+}
+
+fn canonical_server_ids(servers: &[LegacyServer]) -> HashMap<i64, i64> {
+    let mut canonical_by_url = HashMap::<&str, i64>::new();
+    for server in servers {
+        canonical_by_url
+            .entry(server.canonical_url.as_str())
+            .and_modify(|id| *id = (*id).min(server.id))
+            .or_insert(server.id);
+    }
+
+    servers
+        .iter()
+        .map(|server| {
+            let canonical_id = canonical_by_url[server.canonical_url.as_str()];
+            (server.id, canonical_id)
+        })
+        .collect()
+}
+
+fn canonical_server_urls(servers: &[LegacyServer]) -> HashMap<i64, String> {
+    servers
+        .iter()
+        .map(|server| (server.id, server.canonical_url.clone()))
+        .collect()
+}
+
+async fn merge_server_admins(
+    tx: &mut Transaction<'_, Sqlite>,
+    canonical_server_ids: &HashMap<i64, i64>,
+) -> Result<()> {
+    let rows = sqlx::query("SELECT id, server_id FROM server_admins ORDER BY id ASC")
+        .fetch_all(&mut **tx)
+        .await?;
+
+    let mut admin_by_server = HashMap::<i64, i64>::new();
+    let mut duplicate_admin_ids = Vec::new();
+
+    for row in rows {
+        let admin_id = row.get("id");
+        let server_id = row.get("server_id");
+        let Some(&canonical_server_id) = canonical_server_ids.get(&server_id) else {
+            continue;
+        };
+
+        if let Some(existing_admin_id) = admin_by_server.get_mut(&canonical_server_id) {
+            duplicate_admin_ids.push(admin_id);
+            *existing_admin_id = (*existing_admin_id).min(admin_id);
+        } else {
+            admin_by_server.insert(canonical_server_id, admin_id);
+        }
+    }
+
+    for admin_id in duplicate_admin_ids {
+        sqlx::query("DELETE FROM server_admins WHERE id = ?")
+            .bind(admin_id)
+            .execute(&mut **tx)
+            .await?;
+    }
+
+    for (canonical_server_id, admin_id) in admin_by_server {
+        sqlx::query("UPDATE server_admins SET server_id = ? WHERE id = ?")
+            .bind(canonical_server_id)
+            .bind(admin_id)
+            .execute(&mut **tx)
+            .await?;
+    }
+
+    Ok(())
+}
+
+async fn canonicalize_server_mappings(
+    tx: &mut Transaction<'_, Sqlite>,
+    has_server_id: bool,
+    canonical_server_ids: &HashMap<i64, i64>,
+    canonical_server_urls: &HashMap<i64, String>,
+) -> Result<()> {
+    let rows = if has_server_id {
+        sqlx::query(
+            "SELECT id, user_id, server_id, server_url FROM server_mappings ORDER BY id ASC",
+        )
+        .fetch_all(&mut **tx)
+        .await?
+    } else {
+        sqlx::query("SELECT id, user_id, NULL as server_id, server_url FROM server_mappings ORDER BY id ASC")
+            .fetch_all(&mut **tx)
+            .await?
+    };
+
+    let mut groups = HashMap::<(String, String), Vec<LegacyMapping>>::new();
+    for row in rows {
+        let server_id = row.get::<Option<i64>, _>("server_id");
+        let server_url: String = row.get("server_url");
+        let canonical_url = if let Some(server_id) = server_id {
+            let canonical_server_id = canonical_server_ids
+                .get(&server_id)
+                .copied()
+                .unwrap_or(server_id);
+            canonical_server_urls
+                .get(&canonical_server_id)
+                .cloned()
+                .ok_or_else(|| anyhow!("Missing canonical URL for server id {server_id}"))?
+        } else {
+            ServerUrl::canonicalize(&server_url).with_context(|| {
+                format!(
+                    "Invalid server mapping URL in database for mapping {}: {server_url}",
+                    row.get::<i64, _>("id")
+                )
+            })?
+        };
+
+        groups
+            .entry((row.get("user_id"), canonical_url))
+            .or_default()
+            .push(LegacyMapping {
+                id: row.get("id"),
+                server_id,
+                server_url,
+            });
+    }
+
+    for ((_, canonical_url), mut mappings) in groups {
+        mappings.sort_by_key(|mapping| mapping.id);
+        let canonical_mapping_id = mappings[0].id;
+        let duplicate_mapping_ids = mappings
+            .iter()
+            .skip(1)
+            .map(|mapping| mapping.id)
+            .collect::<Vec<_>>();
+
+        merge_authorization_sessions(tx, canonical_mapping_id, &duplicate_mapping_ids).await?;
+
+        for duplicate_mapping_id in duplicate_mapping_ids {
+            sqlx::query("DELETE FROM server_mappings WHERE id = ?")
+                .bind(duplicate_mapping_id)
+                .execute(&mut **tx)
+                .await?;
+        }
+
+        if has_server_id {
+            let server_id = mappings[0]
+                .server_id
+                .and_then(|server_id| canonical_server_ids.get(&server_id).copied())
+                .ok_or_else(|| anyhow!("Missing server id for mapping {}", mappings[0].id))?;
+            sqlx::query("UPDATE server_mappings SET server_id = ?, server_url = ? WHERE id = ?")
+                .bind(server_id)
+                .bind(&canonical_url)
+                .bind(canonical_mapping_id)
+                .execute(&mut **tx)
+                .await?;
+        } else if mappings[0].server_url != canonical_url {
+            sqlx::query("UPDATE server_mappings SET server_url = ? WHERE id = ?")
+                .bind(&canonical_url)
+                .bind(canonical_mapping_id)
+                .execute(&mut **tx)
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn merge_authorization_sessions(
+    tx: &mut Transaction<'_, Sqlite>,
+    canonical_mapping_id: i64,
+    duplicate_mapping_ids: &[i64],
+) -> Result<()> {
+    if duplicate_mapping_ids.is_empty() || !table_exists(tx, "authorization_sessions").await? {
+        return Ok(());
+    }
+
+    let mut mapping_ids = Vec::with_capacity(duplicate_mapping_ids.len() + 1);
+    mapping_ids.push(canonical_mapping_id);
+    mapping_ids.extend_from_slice(duplicate_mapping_ids);
+
+    let has_updated_at = column_exists(tx, "authorization_sessions", "updated_at").await?;
+    let has_created_at = column_exists(tx, "authorization_sessions", "created_at").await?;
+    let order_by = match (has_updated_at, has_created_at) {
+        (true, true) => "updated_at DESC, created_at DESC, id DESC",
+        (true, false) => "updated_at DESC, id DESC",
+        (false, true) => "created_at DESC, id DESC",
+        (false, false) => "id DESC",
+    };
+
+    let mapping_placeholders = placeholders(mapping_ids.len());
+    let rows = sqlx::query(&format!(
+        "SELECT id, user_id, device_id FROM authorization_sessions WHERE mapping_id IN ({mapping_placeholders}) ORDER BY {order_by}"
+    ))
+    .try_bind_all(&mapping_ids)?
+    .fetch_all(&mut **tx)
+    .await?;
+
+    let mut session_by_device = HashMap::<(String, String), i64>::new();
+    let mut duplicate_session_ids = Vec::new();
+
+    for row in rows {
+        let session_id = row.get("id");
+        let key = (row.get("user_id"), row.get("device_id"));
+        if session_by_device.insert(key, session_id).is_some() {
+            duplicate_session_ids.push(session_id);
+        }
+    }
+
+    for session_id in duplicate_session_ids {
+        sqlx::query("DELETE FROM authorization_sessions WHERE id = ?")
+            .bind(session_id)
+            .execute(&mut **tx)
+            .await?;
+    }
+
+    let duplicate_placeholders = placeholders(duplicate_mapping_ids.len());
+    sqlx::query(&format!(
+        "UPDATE authorization_sessions SET mapping_id = ? WHERE mapping_id IN ({duplicate_placeholders})"
+    ))
+    .bind(canonical_mapping_id)
+    .try_bind_all(duplicate_mapping_ids)?
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(())
+}
+
+async fn canonicalize_media_mappings(
+    tx: &mut Transaction<'_, Sqlite>,
+    has_server_id: bool,
+    canonical_server_ids: &HashMap<i64, i64>,
+    canonical_server_urls: &HashMap<i64, String>,
+) -> Result<()> {
+    let rows = if has_server_id {
+        sqlx::query("SELECT id, original_media_id, server_id, server_url FROM media_mappings ORDER BY id ASC")
+            .fetch_all(&mut **tx)
+            .await?
+    } else {
+        sqlx::query("SELECT id, original_media_id, NULL as server_id, server_url FROM media_mappings ORDER BY id ASC")
+            .fetch_all(&mut **tx)
+            .await?
+    };
+
+    let mut groups = HashMap::<(String, String), Vec<LegacyMediaMapping>>::new();
+    for row in rows {
+        let server_id = row.get::<Option<i64>, _>("server_id");
+        let server_url: String = row.get("server_url");
+        let canonical_url = if let Some(server_id) = server_id {
+            let canonical_server_id = canonical_server_ids
+                .get(&server_id)
+                .copied()
+                .unwrap_or(server_id);
+            canonical_server_urls
+                .get(&canonical_server_id)
+                .cloned()
+                .ok_or_else(|| anyhow!("Missing canonical URL for server id {server_id}"))?
+        } else {
+            ServerUrl::canonicalize(&server_url).with_context(|| {
+                format!(
+                    "Invalid media mapping URL in database for mapping {}: {server_url}",
+                    row.get::<i64, _>("id")
+                )
+            })?
+        };
+
+        groups
+            .entry((row.get("original_media_id"), canonical_url))
+            .or_default()
+            .push(LegacyMediaMapping {
+                id: row.get("id"),
+                server_id,
+                server_url,
+            });
+    }
+
+    for ((_, canonical_url), mut mappings) in groups {
+        mappings.sort_by_key(|mapping| mapping.id);
+        let canonical_mapping_id = mappings[0].id;
+
+        for duplicate_mapping in mappings.iter().skip(1) {
+            sqlx::query("DELETE FROM media_mappings WHERE id = ?")
+                .bind(duplicate_mapping.id)
+                .execute(&mut **tx)
+                .await?;
+        }
+
+        if has_server_id {
+            let server_id = mappings[0]
+                .server_id
+                .and_then(|server_id| canonical_server_ids.get(&server_id).copied())
+                .ok_or_else(|| anyhow!("Missing server id for media mapping {}", mappings[0].id))?;
+            sqlx::query("UPDATE media_mappings SET server_id = ?, server_url = ? WHERE id = ?")
+                .bind(server_id)
+                .bind(&canonical_url)
+                .bind(canonical_mapping_id)
+                .execute(&mut **tx)
+                .await?;
+        } else if mappings[0].server_url != canonical_url {
+            sqlx::query("UPDATE media_mappings SET server_url = ? WHERE id = ?")
+                .bind(&canonical_url)
+                .bind(canonical_mapping_id)
+                .execute(&mut **tx)
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn merge_servers(tx: &mut Transaction<'_, Sqlite>, servers: &[LegacyServer]) -> Result<()> {
+    let mut canonical_by_url = HashMap::<&str, i64>::new();
+    for server in servers {
+        canonical_by_url
+            .entry(server.canonical_url.as_str())
+            .and_modify(|id| *id = (*id).min(server.id))
+            .or_insert(server.id);
+    }
+
+    for server in servers {
+        let canonical_id = canonical_by_url[server.canonical_url.as_str()];
+        if server.id != canonical_id {
+            sqlx::query("DELETE FROM servers WHERE id = ?")
+                .bind(server.id)
+                .execute(&mut **tx)
+                .await?;
+        }
+    }
+
+    for server in servers {
+        let canonical_id = canonical_by_url[server.canonical_url.as_str()];
+        if server.id == canonical_id {
+            sqlx::query("UPDATE servers SET url = ? WHERE id = ?")
+                .bind(&server.canonical_url)
+                .bind(server.id)
+                .execute(&mut **tx)
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn placeholders(count: usize) -> String {
+    std::iter::repeat_n("?", count)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+trait BindAll<'q> {
+    fn try_bind_all(
+        self,
+        values: &'q [i64],
+    ) -> Result<sqlx::query::Query<'q, Sqlite, sqlx::sqlite::SqliteArguments<'q>>>;
+}
+
+impl<'q> BindAll<'q> for sqlx::query::Query<'q, Sqlite, sqlx::sqlite::SqliteArguments<'q>> {
+    fn try_bind_all(
+        mut self,
+        values: &'q [i64],
+    ) -> Result<sqlx::query::Query<'q, Sqlite, sqlx::sqlite::SqliteArguments<'q>>> {
+        for value in values {
+            self = self.bind(*value);
+        }
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn cleanup_merges_canonical_server_identity_without_orphaning_sessions() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+
+        sqlx::query(
+            r#"
+            CREATE TABLE servers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                url TEXT NOT NULL,
+                priority INTEGER NOT NULL DEFAULT 100,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r#"
+            CREATE TABLE server_admins (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                server_id INTEGER NOT NULL UNIQUE,
+                username TEXT NOT NULL,
+                password TEXT NOT NULL
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r#"
+            CREATE TABLE server_mappings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id TEXT NOT NULL,
+                server_url TEXT NOT NULL,
+                mapped_username TEXT NOT NULL,
+                mapped_password TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(user_id, server_url)
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r#"
+            CREATE TABLE authorization_sessions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id TEXT NOT NULL,
+                mapping_id INTEGER NOT NULL,
+                server_url TEXT NOT NULL,
+                client TEXT NOT NULL,
+                device TEXT NOT NULL,
+                device_id TEXT NOT NULL,
+                version TEXT NOT NULL,
+                jellyfin_token TEXT,
+                original_user_id TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(user_id, mapping_id, device_id)
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r#"
+            CREATE TABLE media_mappings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                virtual_media_id TEXT NOT NULL UNIQUE,
+                original_media_id TEXT NOT NULL,
+                server_url TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(original_media_id, server_url)
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query("INSERT INTO servers (name, url) VALUES (?, ?), (?, ?), (?, ?)")
+            .bind("one")
+            .bind("https://Example.com/jellyfin///?x=1#fragment")
+            .bind("duplicate")
+            .bind("https://example.com/jellyfin/")
+            .bind("other")
+            .bind("https://other.example")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO server_admins (server_id, username, password) VALUES (1, 'a', 'p'), (2, 'b', 'p')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO server_mappings (user_id, server_url, mapped_username, mapped_password) VALUES (?, ?, 'u', 'p'), (?, ?, 'u', 'p'), (?, ?, 'v', 'p')",
+        )
+        .bind("user")
+        .bind("https://example.com/jellyfin/?query=1")
+        .bind("user")
+        .bind("https://example.com/jellyfin/")
+        .bind("other-user")
+        .bind("https://other.example/")
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r#"
+            INSERT INTO authorization_sessions
+                (id, user_id, mapping_id, server_url, client, device, device_id, version, jellyfin_token, original_user_id, created_at, updated_at)
+            VALUES
+                (10, 'user', 1, 'https://example.com/jellyfin/?query=1', 'c', 'd', 'same-device', '1', 'token-old', 'orig', '2026-01-01 00:00:00Z', '2026-01-01 00:00:00Z'),
+                (5, 'user', 2, 'https://example.com/jellyfin/', 'c', 'd', 'same-device', '1', 'token-new', 'orig', '2026-01-02 00:00:00Z', '2026-01-02 00:00:00Z'),
+                (6, 'user', 2, 'https://example.com/jellyfin/', 'c', 'd', 'other-device', '1', 'token-other', 'orig', '2026-01-02 00:00:00Z', '2026-01-02 00:00:00Z')
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO media_mappings (virtual_media_id, original_media_id, server_url) VALUES ('v1', 'item', ?), ('v2', 'item', ?)",
+        )
+        .bind("https://example.com/jellyfin/?query=1")
+        .bind("https://example.com/jellyfin/")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        canonicalize_legacy_server_identity(&pool).await.unwrap();
+
+        let server_count = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM servers")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(server_count, 2);
+
+        let canonical_url = sqlx::query_scalar::<_, String>("SELECT url FROM servers WHERE id = 1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(canonical_url, "https://example.com/jellyfin");
+
+        let admin_count =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM server_admins WHERE server_id = 1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(admin_count, 1);
+
+        let mapping_count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM server_mappings WHERE user_id = 'user'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(mapping_count, 1);
+
+        let orphaned_sessions = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COUNT(*)
+            FROM authorization_sessions auth
+            LEFT JOIN server_mappings mapping ON mapping.id = auth.mapping_id
+            WHERE mapping.id IS NULL
+            "#,
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(orphaned_sessions, 0);
+
+        let session_count =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM authorization_sessions")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(session_count, 2);
+
+        let same_device_token = sqlx::query_scalar::<_, String>(
+            "SELECT jellyfin_token FROM authorization_sessions WHERE device_id = 'same-device'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(same_device_token, "token-new");
+
+        let media_count = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM media_mappings")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(media_count, 1);
+    }
+}

--- a/crates/jellyswarrm-proxy/src/main.rs
+++ b/crates/jellyswarrm-proxy/src/main.rs
@@ -10,7 +10,7 @@ use axum::{
 use axum_messages::MessagesManagerLayer;
 use percent_encoding::percent_decode_str;
 use rust_embed::RustEmbed;
-use sqlx::{sqlite::SqliteConnectOptions, SqlitePool};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use std::{net::SocketAddr, str::FromStr};
 use std::{sync::Arc, time::Duration};
 use tokio::task::AbortHandle;
@@ -30,11 +30,14 @@ mod config;
 mod encryption;
 mod federated_users;
 mod handlers;
+mod legacy_server_identity;
 mod media_storage_service;
 mod models;
 mod processors;
 mod request_preprocessing;
+mod server_id;
 mod server_storage;
+mod server_url;
 mod session_storage;
 mod ui;
 mod url_helper;
@@ -42,6 +45,7 @@ mod user_authorization_service;
 
 use federated_users::FederatedUserService;
 use handlers::syncplay::SyncPlayService;
+use legacy_server_identity::canonicalize_legacy_server_identity;
 use media_storage_service::MediaStorageService;
 use server_storage::ServerStorageService;
 use user_authorization_service::UserAuthorizationService;
@@ -210,7 +214,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let db_url = format!("sqlite://{}", db_path.to_string_lossy());
     let options = SqliteConnectOptions::from_str(&db_url)?.create_if_missing(true);
 
-    let pool = SqlitePool::connect_with(options).await?;
+    let pool = SqlitePoolOptions::new()
+        .after_connect(|connection, _| {
+            Box::pin(async move {
+                sqlx::query("PRAGMA foreign_keys = ON;")
+                    .execute(connection)
+                    .await?;
+                Ok(())
+            })
+        })
+        .connect_with(options)
+        .await?;
+
+    canonicalize_legacy_server_identity(&pool)
+        .await
+        .unwrap_or_else(|e| {
+            error!(
+                "Failed to canonicalize legacy server identity data: {:#}",
+                e
+            );
+            std::process::exit(1);
+        });
 
     MIGRATOR.run(&pool).await.unwrap_or_else(|e| {
         error!("Failed to run database migrations: {}", e);

--- a/crates/jellyswarrm-proxy/src/media_storage_service.rs
+++ b/crates/jellyswarrm-proxy/src/media_storage_service.rs
@@ -1,21 +1,38 @@
 use std::time::Duration;
 
-use sqlx::{FromRow, Row, SqlitePool};
+use sqlx::{sqlite::SqliteRow, Row, SqlitePool};
 use tracing::{debug, error, info, trace};
 use uuid::Uuid;
 
 use crate::config::MediaStreamingMode;
 use crate::models::generate_token;
-use crate::server_storage::Server;
+use crate::server_id::ServerId;
+use crate::server_storage::{parse_server_url_column, Server};
+#[cfg(test)]
+use crate::server_url::ServerUrl;
 use moka::future::Cache;
 
-#[derive(Debug, Clone, FromRow)]
+#[derive(Debug, Clone)]
 pub struct MediaMapping {
     pub id: i64,
     pub virtual_media_id: String,
     pub original_media_id: String,
+    pub server_id: ServerId,
     pub server_url: String,
     pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl<'r> sqlx::FromRow<'r, SqliteRow> for MediaMapping {
+    fn from_row(row: &SqliteRow) -> Result<Self, sqlx::Error> {
+        Ok(Self {
+            id: row.try_get("id")?,
+            virtual_media_id: row.try_get("virtual_media_id")?,
+            original_media_id: row.try_get("original_media_id")?,
+            server_id: ServerId::new(row.try_get("server_id")?),
+            server_url: row.try_get("server_url")?,
+            created_at: row.try_get("created_at")?,
+        })
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -44,15 +61,17 @@ impl MediaStorageService {
     pub async fn get_or_create_media_mapping(
         &self,
         original_media_id: &str,
-        server_url: &str,
+        server: &Server,
     ) -> Result<MediaMapping, sqlx::Error> {
-        let key = format!("{}|{}", original_media_id, server_url);
+        let original_media_id = Self::normalize_uuid(original_media_id);
+        let server_id = server.id;
+        let key = format!("{}|{}", original_media_id, server_id);
         if let Some(cached) = self.original_mapping_cache.get(&key).await {
             trace!("Cache hit for media mapping: {}", key);
             return Ok(cached);
         }
         let mapping = self
-            ._get_or_create_media_mapping(original_media_id, server_url)
+            ._get_or_create_media_mapping(&original_media_id, server)
             .await?;
         self.original_mapping_cache
             .insert(key, mapping.clone())
@@ -63,13 +82,13 @@ impl MediaStorageService {
     async fn _get_or_create_media_mapping(
         &self,
         original_media_id: &str,
-        server_url: &str,
+        server: &Server,
     ) -> Result<MediaMapping, sqlx::Error> {
         let original_media_id = Self::normalize_uuid(original_media_id);
 
         // Try to find existing mapping
         if let Some(mapping) = self
-            .get_media_mapping_by_original(&original_media_id, server_url)
+            .get_media_mapping_by_original(&original_media_id, server.id)
             .await?
         {
             return Ok(mapping);
@@ -81,15 +100,16 @@ impl MediaStorageService {
 
         let inserted = sqlx::query_as::<_, MediaMapping>(
             r#"
-            INSERT INTO media_mappings (virtual_media_id, original_media_id, server_url, created_at)
-            VALUES (?, ?, ?, ?)
-            ON CONFLICT(original_media_id, server_url) DO NOTHING
-            RETURNING id, virtual_media_id, original_media_id, server_url, created_at
+            INSERT INTO media_mappings (virtual_media_id, original_media_id, server_id, server_url, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(original_media_id, server_id) DO NOTHING
+            RETURNING id, virtual_media_id, original_media_id, server_id, server_url, created_at
             "#,
         )
         .bind(&virtual_media_id)
         .bind(&original_media_id)
-        .bind(server_url)
+        .bind(server.id.as_i64())
+        .bind(server.url.as_str())
         .bind(now)
         .fetch_optional(&self.pool)
         .await?;
@@ -97,14 +117,16 @@ impl MediaStorageService {
         if let Some(row) = inserted {
             debug!(
                 "Created new media mapping: {} -> {} ({})",
-                &original_media_id, row.virtual_media_id, server_url
+                &original_media_id,
+                row.virtual_media_id,
+                server.url.as_str()
             );
             return Ok(row);
         }
 
         // Conflict path: fetch existing row. Happens if another process created it concurrently
         if let Some(existing) = self
-            .get_media_mapping_by_original(&original_media_id, server_url)
+            .get_media_mapping_by_original(&original_media_id, server.id)
             .await?
         {
             return Ok(existing);
@@ -130,7 +152,7 @@ impl MediaStorageService {
 
         let mapping = sqlx::query_as::<_, MediaMapping>(
             r#"
-            SELECT id, virtual_media_id, original_media_id, server_url, created_at
+            SELECT id, virtual_media_id, original_media_id, server_id, server_url, created_at
             FROM media_mappings 
             WHERE virtual_media_id = ?
             "#,
@@ -146,19 +168,19 @@ impl MediaStorageService {
     pub async fn get_media_mapping_by_original(
         &self,
         original_media_id: &str,
-        server_url: &str,
+        server_id: ServerId,
     ) -> Result<Option<MediaMapping>, sqlx::Error> {
         let original_media_id = Self::normalize_uuid(original_media_id);
 
         let mapping = sqlx::query_as::<_, MediaMapping>(
             r#"
-            SELECT id, virtual_media_id, original_media_id, server_url, created_at
+            SELECT id, virtual_media_id, original_media_id, server_id, server_url, created_at
             FROM media_mappings 
-            WHERE original_media_id = ? AND server_url = ?
+            WHERE original_media_id = ? AND server_id = ?
             "#,
         )
         .bind(original_media_id)
-        .bind(server_url)
+        .bind(server_id.as_i64())
         .fetch_optional(&self.pool)
         .await?;
 
@@ -186,6 +208,7 @@ impl MediaStorageService {
                 m.id as media_id,
                 m.virtual_media_id,
                 m.original_media_id,
+                m.server_id as media_server_id,
                 m.server_url as media_server_url,
                 m.created_at as media_created_at,
                 
@@ -197,7 +220,7 @@ impl MediaStorageService {
                 s.created_at as server_created_at,
                 s.updated_at as server_updated_at
             FROM media_mappings m
-            JOIN servers s ON RTRIM(m.server_url, '/') = RTRIM(s.url, '/')
+            JOIN servers s ON m.server_id = s.id
             WHERE m.virtual_media_id = ?
             "#,
         )
@@ -210,14 +233,15 @@ impl MediaStorageService {
                 id: row.get("media_id"),
                 virtual_media_id: row.get("virtual_media_id"),
                 original_media_id: row.get("original_media_id"),
+                server_id: ServerId::new(row.get("media_server_id")),
                 server_url: row.get("media_server_url"),
                 created_at: row.get("media_created_at"),
             };
 
             let server = Server {
-                id: row.get("server_id"),
+                id: ServerId::new(row.get("server_id")),
                 name: row.get("server_name"),
-                url: url::Url::parse(row.get::<String, _>("server_url_full").as_str()).unwrap(),
+                url: parse_server_url_column("server_url_full", row.get("server_url_full"))?,
                 priority: row.get("priority"),
                 media_streaming_mode: row
                     .get::<String, _>("media_streaming_mode")
@@ -274,14 +298,14 @@ impl MediaStorageService {
     /// Delete all media mappings for a specific server
     pub async fn delete_media_mappings_by_server(
         &self,
-        server_url: &str,
+        server: &Server,
     ) -> Result<u64, sqlx::Error> {
         let result = sqlx::query(
             r#"
-            DELETE FROM media_mappings WHERE server_url = ?
+            DELETE FROM media_mappings WHERE server_id = ?
             "#,
         )
-        .bind(server_url)
+        .bind(server.id.as_i64())
         .execute(&self.pool)
         .await?;
 
@@ -289,7 +313,8 @@ impl MediaStorageService {
         if deleted_count > 0 {
             info!(
                 "Deleted {} media mappings for server: {}",
-                deleted_count, server_url
+                deleted_count,
+                server.url.as_str()
             );
         }
         self.original_mapping_cache.invalidate_all();
@@ -304,15 +329,44 @@ mod tests {
 
     use super::*;
 
+    async fn create_test_server(pool: &SqlitePool) -> Server {
+        let now = chrono::Utc::now();
+        let result = sqlx::query(
+            r#"
+            INSERT INTO servers (name, url, priority, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind("Test Server")
+        .bind("http://localhost:8096")
+        .bind(100)
+        .bind(now)
+        .bind(now)
+        .execute(pool)
+        .await
+        .unwrap();
+
+        Server {
+            id: ServerId::new(result.last_insert_rowid()),
+            name: "Test Server".to_string(),
+            url: ServerUrl::parse("http://localhost:8096").unwrap(),
+            priority: 100,
+            media_streaming_mode: MediaStreamingMode::Redirect,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
     #[tokio::test]
     async fn test_media_storage_service() {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
         MIGRATOR.run(&pool).await.unwrap();
         let service = MediaStorageService::new(pool.clone());
+        let server = create_test_server(&pool).await;
 
         // Create media mapping
         let mapping = service
-            .get_or_create_media_mapping("original-movie-123", "http://localhost:8096")
+            .get_or_create_media_mapping("original-movie-123", &server)
             .await
             .unwrap();
 
@@ -335,43 +389,11 @@ mod tests {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
         MIGRATOR.run(&pool).await.unwrap();
         let service = MediaStorageService::new(pool.clone());
-
-        // Create the servers table (normally done by ServerStorageService)
-        sqlx::query(
-            r#"
-            CREATE TABLE IF NOT EXISTS servers (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                name TEXT NOT NULL UNIQUE,
-                url TEXT NOT NULL,
-                priority INTEGER NOT NULL DEFAULT 100,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-            )
-            "#,
-        )
-        .execute(&pool)
-        .await
-        .unwrap();
-
-        // Create a server in the servers table
-        sqlx::query(
-            r#"
-            INSERT INTO servers (name, url, priority, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?)
-            "#,
-        )
-        .bind("Test Server")
-        .bind("http://localhost:8096")
-        .bind(100)
-        .bind(chrono::Utc::now())
-        .bind(chrono::Utc::now())
-        .execute(&pool)
-        .await
-        .unwrap();
+        let server = create_test_server(&pool).await;
 
         // Create media mapping
         let mapping = service
-            .get_or_create_media_mapping("original-movie-123", "http://localhost:8096")
+            .get_or_create_media_mapping("original-movie-123", &server)
             .await
             .unwrap();
 
@@ -385,10 +407,7 @@ mod tests {
         assert_eq!(retrieved_mapping.virtual_media_id, mapping.virtual_media_id);
         assert_eq!(retrieved_mapping.original_media_id, "original-movie-123");
         assert_eq!(server.name, "Test Server");
-        assert_eq!(
-            server.url.as_str().trim_end_matches('/'),
-            "http://localhost:8096"
-        );
+        assert_eq!(server.url.as_str(), "http://localhost:8096");
     }
 
     #[tokio::test]
@@ -396,10 +415,11 @@ mod tests {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
         MIGRATOR.run(&pool).await.unwrap();
         let service = MediaStorageService::new(pool.clone());
+        let server = create_test_server(&pool).await;
 
         // Create media mapping
         let mapping = service
-            .get_or_create_media_mapping("movie-123", "http://localhost:8096")
+            .get_or_create_media_mapping("movie-123", &server)
             .await
             .unwrap();
 

--- a/crates/jellyswarrm-proxy/src/processors/request_analyzer.rs
+++ b/crates/jellyswarrm-proxy/src/processors/request_analyzer.rs
@@ -100,7 +100,19 @@ impl JsonAnalyzer<RequestAnalysisContext, RequestBodyAnalysisResult> for Request
                     .get_session(session_id)
                     .await
                 {
-                    accumulator.servers.push(play_session.server);
+                    if let Some(server) = self
+                        .data_context
+                        .server_storage
+                        .get_server_by_id(play_session.server_id)
+                        .await?
+                    {
+                        accumulator.servers.push(server);
+                    } else {
+                        self.data_context
+                            .play_sessions
+                            .remove_sessions_for_server(play_session.server_id)
+                            .await;
+                    }
                 }
                 accumulator.found_session_ids.push(session_id.clone());
             }

--- a/crates/jellyswarrm-proxy/src/request_preprocessing.rs
+++ b/crates/jellyswarrm-proxy/src/request_preprocessing.rs
@@ -640,11 +640,10 @@ pub async fn resolve_server(
 
     if let Some(sessions) = sessions {
         if let Some(request_server) = request_server {
-            if let Some((session, server)) = sessions.iter().find(|(_, server)| {
-                let request_url = request_server.url.as_str().trim_end_matches('/');
-                let server_url = server.url.as_str().trim_end_matches('/');
-                request_url == server_url
-            }) {
+            if let Some((session, server)) = sessions
+                .iter()
+                .find(|(_, server)| request_server.id == server.id)
+            {
                 debug!("Found server in request: {}", server.url);
                 return Ok((server.clone(), Some(session.clone())));
             }

--- a/crates/jellyswarrm-proxy/src/server_id.rs
+++ b/crates/jellyswarrm-proxy/src/server_id.rs
@@ -1,0 +1,21 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ServerId(i64);
+
+impl ServerId {
+    pub fn new(value: i64) -> Self {
+        Self(value)
+    }
+
+    pub fn as_i64(self) -> i64 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for ServerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/crates/jellyswarrm-proxy/src/server_storage.rs
+++ b/crates/jellyswarrm-proxy/src/server_storage.rs
@@ -1,11 +1,10 @@
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
-use sqlx::{FromRow, Row, SqlitePool};
+use sqlx::{sqlite::SqliteRow, Row, SqlitePool};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{error, info};
-use url::Url;
 
 use jellyfin_api::{
     client::{ClientInfo, JellyfinClient},
@@ -14,26 +13,68 @@ use jellyfin_api::{
 
 use crate::config::MediaStreamingMode;
 use crate::encryption::EncryptedPassword;
+use crate::server_id::ServerId;
+use crate::server_url::ServerUrl;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
 pub struct Server {
-    pub id: i64,
+    pub id: ServerId,
     pub name: String,
-    pub url: Url,
+    pub url: ServerUrl,
     pub priority: i32,
     pub media_streaming_mode: MediaStreamingMode,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+impl Server {
+    pub(crate) fn from_row(row: SqliteRow) -> Result<Self, sqlx::Error> {
+        Ok(Server {
+            id: ServerId::new(row.get("id")),
+            name: row.get("name"),
+            url: parse_server_url_column("url", row.get("url"))?,
+            priority: row.get("priority"),
+            media_streaming_mode: row
+                .get::<String, _>("media_streaming_mode")
+                .parse()
+                .unwrap_or(MediaStreamingMode::Redirect),
+            created_at: row.get("created_at"),
+            updated_at: row.get("updated_at"),
+        })
+    }
+}
+
+pub(crate) fn parse_server_url_column(
+    column: &'static str,
+    value: String,
+) -> Result<ServerUrl, sqlx::Error> {
+    ServerUrl::parse(&value).map_err(|err| sqlx::Error::ColumnDecode {
+        index: column.into(),
+        source: Box::new(err),
+    })
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerAdmin {
     pub id: i64,
-    pub server_id: i64,
+    pub server_id: ServerId,
     pub username: String,
     pub password: EncryptedPassword,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl<'r> sqlx::FromRow<'r, SqliteRow> for ServerAdmin {
+    fn from_row(row: &SqliteRow) -> Result<Self, sqlx::Error> {
+        Ok(Self {
+            id: row.try_get("id")?,
+            server_id: ServerId::new(row.try_get("server_id")?),
+            username: row.try_get("username")?,
+            password: row.try_get("password")?,
+            created_at: row.try_get("created_at")?,
+            updated_at: row.try_get("updated_at")?,
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -53,7 +94,7 @@ impl ServerHealthStatus {
 #[derive(Debug, Clone)]
 pub struct ServerStorageService {
     pool: SqlitePool,
-    health_status: Arc<RwLock<HashMap<i64, ServerHealthStatus>>>,
+    health_status: Arc<RwLock<HashMap<ServerId, ServerHealthStatus>>>,
     pub http_client: reqwest::Client,
     pub client_info: ClientInfo,
 }
@@ -78,14 +119,16 @@ impl ServerStorageService {
         url: &str,
         priority: i32,
         media_streaming_mode: MediaStreamingMode,
-    ) -> Result<i64, sqlx::Error> {
-        // Validate URL
-        if Url::parse(url).is_err() {
-            return Err(sqlx::Error::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "Invalid URL format",
-            )));
-        }
+    ) -> Result<ServerId, sqlx::Error> {
+        let url = match ServerUrl::parse(url) {
+            Ok(url) => url,
+            Err(_) => {
+                return Err(sqlx::Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "Invalid URL format",
+                )))
+            }
+        };
 
         let now = chrono::Utc::now();
 
@@ -96,7 +139,7 @@ impl ServerStorageService {
             "#,
         )
         .bind(name)
-        .bind(url)
+        .bind(url.as_str())
         .bind(priority)
         .bind(media_streaming_mode.to_string())
         .bind(now)
@@ -104,7 +147,7 @@ impl ServerStorageService {
         .execute(&self.pool)
         .await?;
 
-        let server_id = result.last_insert_rowid();
+        let server_id = ServerId::new(result.last_insert_rowid());
         info!(
             "Added server: {} ({}) with priority {}",
             name, url, priority
@@ -124,14 +167,10 @@ impl ServerStorageService {
         .fetch_optional(&self.pool)
         .await?;
 
-        if let Some(row) = row {
-            Ok(Some(self.row_to_server(row)))
-        } else {
-            Ok(None)
-        }
+        row.map(Server::from_row).transpose()
     }
 
-    pub async fn get_server_by_id(&self, id: i64) -> Result<Option<Server>, sqlx::Error> {
+    pub async fn get_server_by_id(&self, id: ServerId) -> Result<Option<Server>, sqlx::Error> {
         let row = sqlx::query(
             r#"
             SELECT id, name, url, priority, media_streaming_mode, created_at, updated_at
@@ -139,15 +178,11 @@ impl ServerStorageService {
             WHERE id = ?
             "#,
         )
-        .bind(id)
+        .bind(id.as_i64())
         .fetch_optional(&self.pool)
         .await?;
 
-        if let Some(row) = row {
-            Ok(Some(self.row_to_server(row)))
-        } else {
-            Ok(None)
-        }
+        row.map(Server::from_row).transpose()
     }
 
     pub async fn list_servers(&self) -> Result<Vec<Server>, sqlx::Error> {
@@ -161,16 +196,12 @@ impl ServerStorageService {
         .fetch_all(&self.pool)
         .await?;
 
-        let servers = rows
-            .into_iter()
-            .map(|row| self.row_to_server(row))
-            .collect();
-        Ok(servers)
+        rows.into_iter().map(Server::from_row).collect()
     }
 
     pub async fn update_server_priority(
         &self,
-        server_id: i64,
+        server_id: ServerId,
         new_priority: i32,
     ) -> Result<bool, sqlx::Error> {
         let now = chrono::Utc::now();
@@ -184,7 +215,7 @@ impl ServerStorageService {
         )
         .bind(new_priority)
         .bind(now)
-        .bind(server_id)
+        .bind(server_id.as_i64())
         .execute(&self.pool)
         .await?;
 
@@ -193,7 +224,7 @@ impl ServerStorageService {
 
     pub async fn update_server_media_streaming_mode(
         &self,
-        server_id: i64,
+        server_id: ServerId,
         media_streaming_mode: MediaStreamingMode,
     ) -> Result<bool, sqlx::Error> {
         let now = chrono::Utc::now();
@@ -207,21 +238,21 @@ impl ServerStorageService {
         )
         .bind(media_streaming_mode.to_string())
         .bind(now)
-        .bind(server_id)
+        .bind(server_id.as_i64())
         .execute(&self.pool)
         .await?;
 
         Ok(result.rows_affected() > 0)
     }
 
-    pub async fn delete_server(&self, server_id: i64) -> Result<bool, sqlx::Error> {
+    pub async fn delete_server(&self, server_id: ServerId) -> Result<bool, sqlx::Error> {
         let result = sqlx::query(
             r#"
             DELETE FROM servers 
             WHERE id = ?
             "#,
         )
-        .bind(server_id)
+        .bind(server_id.as_i64())
         .execute(&self.pool)
         .await?;
 
@@ -264,7 +295,7 @@ impl ServerStorageService {
             }
         };
 
-        let statuses: Vec<(i64, ServerHealthStatus)> =
+        let statuses: Vec<(ServerId, ServerHealthStatus)> =
             futures_util::stream::iter(servers.into_iter().map(|server| {
                 let http_client = self.http_client.clone();
                 let client_info = self.client_info.clone();
@@ -309,7 +340,7 @@ impl ServerStorageService {
         }
     }
 
-    pub async fn server_status(&self, server_id: i64) -> ServerHealthStatus {
+    pub async fn server_status(&self, server_id: ServerId) -> ServerHealthStatus {
         let health = self.health_status.read().await;
         health
             .get(&server_id)
@@ -344,25 +375,9 @@ impl ServerStorageService {
         }
     }
 
-    /// Internal method to convert database row to Server struct
-    fn row_to_server(&self, row: sqlx::sqlite::SqliteRow) -> Server {
-        Server {
-            id: row.get("id"),
-            name: row.get("name"),
-            url: Url::parse(row.get("url")).unwrap(),
-            priority: row.get("priority"),
-            media_streaming_mode: row
-                .get::<String, _>("media_streaming_mode")
-                .parse()
-                .unwrap_or(MediaStreamingMode::Redirect),
-            created_at: row.get("created_at"),
-            updated_at: row.get("updated_at"),
-        }
-    }
-
     pub async fn add_server_admin(
         &self,
-        server_id: i64,
+        server_id: ServerId,
         username: &str,
         password: &EncryptedPassword,
     ) -> Result<i64, sqlx::Error> {
@@ -374,7 +389,7 @@ impl ServerStorageService {
             VALUES (?, ?, ?, ?, ?)
             "#,
         )
-        .bind(server_id)
+        .bind(server_id.as_i64())
         .bind(username)
         .bind(password)
         .bind(now)
@@ -389,7 +404,7 @@ impl ServerStorageService {
 
     pub async fn get_server_admin(
         &self,
-        server_id: i64,
+        server_id: ServerId,
     ) -> Result<Option<ServerAdmin>, sqlx::Error> {
         let row = sqlx::query_as::<_, ServerAdmin>(
             r#"
@@ -398,21 +413,21 @@ impl ServerStorageService {
             WHERE server_id = ?
             "#,
         )
-        .bind(server_id)
+        .bind(server_id.as_i64())
         .fetch_optional(&self.pool)
         .await?;
 
         Ok(row)
     }
 
-    pub async fn delete_server_admin(&self, server_id: i64) -> Result<bool, sqlx::Error> {
+    pub async fn delete_server_admin(&self, server_id: ServerId) -> Result<bool, sqlx::Error> {
         let result = sqlx::query(
             r#"
             DELETE FROM server_admins 
             WHERE server_id = ?
             "#,
         )
-        .bind(server_id)
+        .bind(server_id.as_i64())
         .execute(&self.pool)
         .await?;
 
@@ -450,9 +465,19 @@ mod tests {
 
         let server = server.unwrap();
         assert_eq!(server.name, "test-server");
-        assert_eq!(server.url, Url::parse("http://localhost:8096").unwrap());
+        assert_eq!(server.url.as_str(), "http://localhost:8096");
         assert_eq!(server.priority, 100);
         assert_eq!(server.media_streaming_mode, MediaStreamingMode::Redirect);
+
+        let duplicate_url = service
+            .add_server(
+                "duplicate-url-server",
+                "http://localhost:8096/",
+                100,
+                MediaStreamingMode::Redirect,
+            )
+            .await;
+        assert!(duplicate_url.is_err());
 
         // Test listing servers
         let servers = service.list_servers().await.unwrap();

--- a/crates/jellyswarrm-proxy/src/server_url.rs
+++ b/crates/jellyswarrm-proxy/src/server_url.rs
@@ -1,0 +1,97 @@
+use std::ops::Deref;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use url::Url;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct ServerUrl {
+    url: Url,
+    canonical: String,
+}
+
+impl ServerUrl {
+    pub fn parse(input: &str) -> Result<Self, url::ParseError> {
+        let canonical = Self::canonicalize(input)?;
+        let url = Url::parse(&canonical)?;
+        Ok(Self { url, canonical })
+    }
+
+    pub fn canonicalize(input: &str) -> Result<String, url::ParseError> {
+        let mut url = Url::parse(input.trim())?;
+        url.set_fragment(None);
+        url.set_query(None);
+
+        let mut canonical = url.to_string();
+        while canonical.ends_with('/') {
+            canonical.pop();
+        }
+
+        Ok(canonical)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.canonical
+    }
+
+    pub fn as_url(&self) -> &Url {
+        &self.url
+    }
+}
+
+impl AsRef<str> for ServerUrl {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Deref for ServerUrl {
+    type Target = Url;
+
+    fn deref(&self) -> &Self::Target {
+        &self.url
+    }
+}
+
+impl Serialize for ServerUrl {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ServerUrl {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(&value).map_err(serde::de::Error::custom)
+    }
+}
+
+impl std::fmt::Display for ServerUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalize_removes_trailing_slashes_query_and_fragment() {
+        let url = ServerUrl::parse(" https://Example.COM/jellyfin///?foo=bar#frag ").unwrap();
+
+        assert_eq!(url.as_str(), "https://example.com/jellyfin");
+    }
+
+    #[test]
+    fn canonicalize_keeps_path_case() {
+        let url = ServerUrl::parse("https://example.com/Jellyfin/").unwrap();
+
+        assert_eq!(url.as_str(), "https://example.com/Jellyfin");
+    }
+}

--- a/crates/jellyswarrm-proxy/src/session_storage.rs
+++ b/crates/jellyswarrm-proxy/src/session_storage.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use tokio::sync::RwLock;
 
-use crate::server_storage::Server;
+use crate::server_id::ServerId;
 
 const PLAYBACK_SESSION_TTL: Duration = Duration::from_secs(12 * 60 * 60);
 
@@ -10,7 +10,7 @@ const PLAYBACK_SESSION_TTL: Duration = Duration::from_secs(12 * 60 * 60);
 pub struct PlaybackSession {
     pub session_id: String, // Unique identifier for the session
     pub item_id: String,    // ID of the media item being played
-    pub server: Server,
+    pub server_id: ServerId,
 }
 
 pub struct SessionStorage {
@@ -46,10 +46,10 @@ impl SessionStorage {
         let mut sessions = self.sessions.write().await;
         Self::prune_stale_sessions(&mut sessions, self.session_ttl, now);
 
-        if let Some(index) = sessions
-            .iter()
-            .position(|tracked| tracked.session.session_id == session.session_id)
-        {
+        if let Some(index) = sessions.iter().position(|tracked| {
+            tracked.session.session_id == session.session_id
+                && tracked.session.item_id == session.item_id
+        }) {
             sessions.remove(index);
         }
 
@@ -71,7 +71,11 @@ impl SessionStorage {
             .map(|tracked| tracked.session.clone())
     }
 
-    pub async fn get_session_by_item_id(&self, item_id: &str) -> Option<PlaybackSession> {
+    pub async fn get_session_by_session_and_item_id(
+        &self,
+        session_id: &str,
+        item_id: &str,
+    ) -> Option<PlaybackSession> {
         let now = Instant::now();
         let mut sessions = self.sessions.write().await;
         Self::prune_stale_sessions(&mut sessions, self.session_ttl, now);
@@ -79,13 +83,20 @@ impl SessionStorage {
         sessions
             .iter()
             .rev()
-            .find(|tracked| tracked.session.item_id == item_id)
+            .find(|tracked| {
+                tracked.session.session_id == session_id && tracked.session.item_id == item_id
+            })
             .map(|tracked| tracked.session.clone())
     }
 
     pub async fn remove_session(&self, session_id: &str) {
         let mut sessions = self.sessions.write().await;
         sessions.retain(|tracked| tracked.session.session_id != session_id);
+    }
+
+    pub async fn remove_sessions_for_server(&self, server_id: ServerId) {
+        let mut sessions = self.sessions.write().await;
+        sessions.retain(|tracked| tracked.session.server_id != server_id);
     }
 
     fn prune_stale_sessions(
@@ -100,75 +111,73 @@ impl SessionStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{config::MediaStreamingMode, server_id::ServerId, server_url::ServerUrl};
-
-    fn test_server(id: i64, name: &str) -> Server {
-        let now = chrono::Utc::now();
-        Server {
-            id: ServerId::new(id),
-            name: name.to_string(),
-            url: ServerUrl::parse(&format!("http://server{id}.example")).unwrap(),
-            priority: 100,
-            media_streaming_mode: MediaStreamingMode::Redirect,
-            created_at: now,
-            updated_at: now,
-        }
-    }
 
     #[tokio::test]
-    async fn test_add_session_upserts_by_session_id() {
+    async fn test_add_session_upserts_by_session_and_item_id() {
         let storage = SessionStorage::new();
 
         storage
             .add_session(PlaybackSession {
                 session_id: "session-1".to_string(),
-                item_id: "old-item".to_string(),
-                server: test_server(1, "old"),
+                item_id: "item-1".to_string(),
+                server_id: ServerId::new(1),
             })
             .await;
         storage
             .add_session(PlaybackSession {
                 session_id: "session-1".to_string(),
-                item_id: "new-item".to_string(),
-                server: test_server(2, "new"),
+                item_id: "item-1".to_string(),
+                server_id: ServerId::new(2),
             })
             .await;
 
         let session = storage.get_session("session-1").await.unwrap();
-        assert_eq!(session.server.id, ServerId::new(2));
-        assert!(storage.get_session_by_item_id("old-item").await.is_none());
+        assert_eq!(session.server_id, ServerId::new(2));
         assert_eq!(
             storage
-                .get_session_by_item_id("new-item")
+                .get_session_by_session_and_item_id("session-1", "item-1")
                 .await
                 .unwrap()
-                .server
-                .id,
+                .server_id,
             ServerId::new(2)
         );
     }
 
     #[tokio::test]
-    async fn test_get_session_by_item_id_prefers_newest_match() {
+    async fn test_same_item_id_requires_matching_session_id() {
         let storage = SessionStorage::new();
 
         storage
             .add_session(PlaybackSession {
                 session_id: "session-1".to_string(),
                 item_id: "shared-item".to_string(),
-                server: test_server(1, "old"),
+                server_id: ServerId::new(1),
             })
             .await;
         storage
             .add_session(PlaybackSession {
                 session_id: "session-2".to_string(),
                 item_id: "shared-item".to_string(),
-                server: test_server(2, "new"),
+                server_id: ServerId::new(2),
             })
             .await;
 
-        let session = storage.get_session_by_item_id("shared-item").await.unwrap();
-        assert_eq!(session.server.id, ServerId::new(2));
+        let session = storage
+            .get_session_by_session_and_item_id("session-1", "shared-item")
+            .await
+            .unwrap();
+        assert_eq!(session.server_id, ServerId::new(1));
+
+        let session = storage
+            .get_session_by_session_and_item_id("session-2", "shared-item")
+            .await
+            .unwrap();
+        assert_eq!(session.server_id, ServerId::new(2));
+
+        assert!(storage
+            .get_session_by_session_and_item_id("missing-session", "shared-item")
+            .await
+            .is_none());
     }
 
     #[tokio::test]
@@ -179,13 +188,41 @@ mod tests {
             .add_session(PlaybackSession {
                 session_id: "session-1".to_string(),
                 item_id: "item-1".to_string(),
-                server: test_server(1, "server"),
+                server_id: ServerId::new(1),
             })
             .await;
 
         tokio::time::sleep(Duration::from_millis(10)).await;
 
         assert!(storage.get_session("session-1").await.is_none());
-        assert!(storage.get_session_by_item_id("item-1").await.is_none());
+        assert!(storage
+            .get_session_by_session_and_item_id("session-1", "item-1")
+            .await
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn test_remove_sessions_for_server() {
+        let storage = SessionStorage::new();
+
+        storage
+            .add_session(PlaybackSession {
+                session_id: "session-1".to_string(),
+                item_id: "item-1".to_string(),
+                server_id: ServerId::new(1),
+            })
+            .await;
+        storage
+            .add_session(PlaybackSession {
+                session_id: "session-2".to_string(),
+                item_id: "item-2".to_string(),
+                server_id: ServerId::new(2),
+            })
+            .await;
+
+        storage.remove_sessions_for_server(ServerId::new(1)).await;
+
+        assert!(storage.get_session("session-1").await.is_none());
+        assert!(storage.get_session("session-2").await.is_some());
     }
 }

--- a/crates/jellyswarrm-proxy/src/session_storage.rs
+++ b/crates/jellyswarrm-proxy/src/session_storage.rs
@@ -1,6 +1,10 @@
+use std::time::{Duration, Instant};
+
 use tokio::sync::RwLock;
 
 use crate::server_storage::Server;
+
+const PLAYBACK_SESSION_TTL: Duration = Duration::from_secs(12 * 60 * 60);
 
 #[derive(Clone)]
 pub struct PlaybackSession {
@@ -10,7 +14,13 @@ pub struct PlaybackSession {
 }
 
 pub struct SessionStorage {
-    pub sessions: RwLock<Vec<PlaybackSession>>,
+    sessions: RwLock<Vec<TrackedPlaybackSession>>,
+    session_ttl: Duration,
+}
+
+struct TrackedPlaybackSession {
+    session: PlaybackSession,
+    updated_at: Instant,
 }
 
 impl Default for SessionStorage {
@@ -21,31 +31,161 @@ impl Default for SessionStorage {
 
 impl SessionStorage {
     pub fn new() -> Self {
+        Self::with_session_ttl(PLAYBACK_SESSION_TTL)
+    }
+
+    pub fn with_session_ttl(session_ttl: Duration) -> Self {
         SessionStorage {
             sessions: RwLock::new(Vec::new()),
+            session_ttl,
         }
     }
 
     pub async fn add_session(&self, session: PlaybackSession) {
+        let now = Instant::now();
         let mut sessions = self.sessions.write().await;
-        sessions.push(session);
+        Self::prune_stale_sessions(&mut sessions, self.session_ttl, now);
+
+        if let Some(index) = sessions
+            .iter()
+            .position(|tracked| tracked.session.session_id == session.session_id)
+        {
+            sessions.remove(index);
+        }
+
+        sessions.push(TrackedPlaybackSession {
+            session,
+            updated_at: now,
+        });
     }
 
     pub async fn get_session(&self, session_id: &str) -> Option<PlaybackSession> {
-        let sessions = self.sessions.read().await;
+        let now = Instant::now();
+        let mut sessions = self.sessions.write().await;
+        Self::prune_stale_sessions(&mut sessions, self.session_ttl, now);
+
         sessions
             .iter()
-            .find(|s| s.session_id == session_id)
-            .cloned()
+            .rev()
+            .find(|tracked| tracked.session.session_id == session_id)
+            .map(|tracked| tracked.session.clone())
     }
 
     pub async fn get_session_by_item_id(&self, item_id: &str) -> Option<PlaybackSession> {
-        let sessions = self.sessions.read().await;
-        sessions.iter().find(|s| s.item_id == item_id).cloned()
+        let now = Instant::now();
+        let mut sessions = self.sessions.write().await;
+        Self::prune_stale_sessions(&mut sessions, self.session_ttl, now);
+
+        sessions
+            .iter()
+            .rev()
+            .find(|tracked| tracked.session.item_id == item_id)
+            .map(|tracked| tracked.session.clone())
     }
 
     pub async fn remove_session(&self, session_id: &str) {
         let mut sessions = self.sessions.write().await;
-        sessions.retain(|s| s.session_id != session_id);
+        sessions.retain(|tracked| tracked.session.session_id != session_id);
+    }
+
+    fn prune_stale_sessions(
+        sessions: &mut Vec<TrackedPlaybackSession>,
+        session_ttl: Duration,
+        now: Instant,
+    ) {
+        sessions.retain(|tracked| now.duration_since(tracked.updated_at) <= session_ttl);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{config::MediaStreamingMode, server_id::ServerId, server_url::ServerUrl};
+
+    fn test_server(id: i64, name: &str) -> Server {
+        let now = chrono::Utc::now();
+        Server {
+            id: ServerId::new(id),
+            name: name.to_string(),
+            url: ServerUrl::parse(&format!("http://server{id}.example")).unwrap(),
+            priority: 100,
+            media_streaming_mode: MediaStreamingMode::Redirect,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_add_session_upserts_by_session_id() {
+        let storage = SessionStorage::new();
+
+        storage
+            .add_session(PlaybackSession {
+                session_id: "session-1".to_string(),
+                item_id: "old-item".to_string(),
+                server: test_server(1, "old"),
+            })
+            .await;
+        storage
+            .add_session(PlaybackSession {
+                session_id: "session-1".to_string(),
+                item_id: "new-item".to_string(),
+                server: test_server(2, "new"),
+            })
+            .await;
+
+        let session = storage.get_session("session-1").await.unwrap();
+        assert_eq!(session.server.id, ServerId::new(2));
+        assert!(storage.get_session_by_item_id("old-item").await.is_none());
+        assert_eq!(
+            storage
+                .get_session_by_item_id("new-item")
+                .await
+                .unwrap()
+                .server
+                .id,
+            ServerId::new(2)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_session_by_item_id_prefers_newest_match() {
+        let storage = SessionStorage::new();
+
+        storage
+            .add_session(PlaybackSession {
+                session_id: "session-1".to_string(),
+                item_id: "shared-item".to_string(),
+                server: test_server(1, "old"),
+            })
+            .await;
+        storage
+            .add_session(PlaybackSession {
+                session_id: "session-2".to_string(),
+                item_id: "shared-item".to_string(),
+                server: test_server(2, "new"),
+            })
+            .await;
+
+        let session = storage.get_session_by_item_id("shared-item").await.unwrap();
+        assert_eq!(session.server.id, ServerId::new(2));
+    }
+
+    #[tokio::test]
+    async fn test_stale_sessions_expire() {
+        let storage = SessionStorage::with_session_ttl(Duration::from_millis(1));
+
+        storage
+            .add_session(PlaybackSession {
+                session_id: "session-1".to_string(),
+                item_id: "item-1".to_string(),
+                server: test_server(1, "server"),
+            })
+            .await;
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        assert!(storage.get_session("session-1").await.is_none());
+        assert!(storage.get_session_by_item_id("item-1").await.is_none());
     }
 }

--- a/crates/jellyswarrm-proxy/src/session_storage.rs
+++ b/crates/jellyswarrm-proxy/src/session_storage.rs
@@ -10,6 +10,7 @@ const PLAYBACK_SESSION_TTL: Duration = Duration::from_secs(12 * 60 * 60);
 pub struct PlaybackSession {
     pub session_id: String, // Unique identifier for the session
     pub item_id: String,    // ID of the media item being played
+    pub user_id: String,
     pub server_id: ServerId,
 }
 
@@ -89,6 +90,19 @@ impl SessionStorage {
             .map(|tracked| tracked.session.clone())
     }
 
+    pub async fn get_sessions_by_item_id(&self, item_id: &str) -> Vec<PlaybackSession> {
+        let now = Instant::now();
+        let mut sessions = self.sessions.write().await;
+        Self::prune_stale_sessions(&mut sessions, self.session_ttl, now);
+
+        sessions
+            .iter()
+            .rev()
+            .filter(|tracked| tracked.session.item_id == item_id)
+            .map(|tracked| tracked.session.clone())
+            .collect()
+    }
+
     pub async fn remove_session(&self, session_id: &str) {
         let mut sessions = self.sessions.write().await;
         sessions.retain(|tracked| tracked.session.session_id != session_id);
@@ -120,6 +134,7 @@ mod tests {
             .add_session(PlaybackSession {
                 session_id: "session-1".to_string(),
                 item_id: "item-1".to_string(),
+                user_id: "user-1".to_string(),
                 server_id: ServerId::new(1),
             })
             .await;
@@ -127,6 +142,7 @@ mod tests {
             .add_session(PlaybackSession {
                 session_id: "session-1".to_string(),
                 item_id: "item-1".to_string(),
+                user_id: "user-1".to_string(),
                 server_id: ServerId::new(2),
             })
             .await;
@@ -151,6 +167,7 @@ mod tests {
             .add_session(PlaybackSession {
                 session_id: "session-1".to_string(),
                 item_id: "shared-item".to_string(),
+                user_id: "user-1".to_string(),
                 server_id: ServerId::new(1),
             })
             .await;
@@ -158,6 +175,7 @@ mod tests {
             .add_session(PlaybackSession {
                 session_id: "session-2".to_string(),
                 item_id: "shared-item".to_string(),
+                user_id: "user-1".to_string(),
                 server_id: ServerId::new(2),
             })
             .await;
@@ -188,6 +206,7 @@ mod tests {
             .add_session(PlaybackSession {
                 session_id: "session-1".to_string(),
                 item_id: "item-1".to_string(),
+                user_id: "user-1".to_string(),
                 server_id: ServerId::new(1),
             })
             .await;
@@ -209,6 +228,7 @@ mod tests {
             .add_session(PlaybackSession {
                 session_id: "session-1".to_string(),
                 item_id: "item-1".to_string(),
+                user_id: "user-1".to_string(),
                 server_id: ServerId::new(1),
             })
             .await;
@@ -216,6 +236,7 @@ mod tests {
             .add_session(PlaybackSession {
                 session_id: "session-2".to_string(),
                 item_id: "item-2".to_string(),
+                user_id: "user-1".to_string(),
                 server_id: ServerId::new(2),
             })
             .await;
@@ -224,5 +245,32 @@ mod tests {
 
         assert!(storage.get_session("session-1").await.is_none());
         assert!(storage.get_session("session-2").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_get_sessions_by_item_id_returns_active_matches_newest_first() {
+        let storage = SessionStorage::new();
+
+        storage
+            .add_session(PlaybackSession {
+                session_id: "session-1".to_string(),
+                item_id: "shared-item".to_string(),
+                user_id: "user-1".to_string(),
+                server_id: ServerId::new(1),
+            })
+            .await;
+        storage
+            .add_session(PlaybackSession {
+                session_id: "session-2".to_string(),
+                item_id: "shared-item".to_string(),
+                user_id: "user-2".to_string(),
+                server_id: ServerId::new(2),
+            })
+            .await;
+
+        let sessions = storage.get_sessions_by_item_id("shared-item").await;
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].session_id, "session-2");
+        assert_eq!(sessions[1].session_id, "session-1");
     }
 }

--- a/crates/jellyswarrm-proxy/src/ui/admin/servers.rs
+++ b/crates/jellyswarrm-proxy/src/ui/admin/servers.rs
@@ -268,6 +268,10 @@ pub async fn delete_server(
 ) -> Response {
     match state.server_storage.delete_server(server_id).await {
         Ok(true) => {
+            state
+                .play_sessions
+                .remove_sessions_for_server(server_id)
+                .await;
             info!("Deleted server with ID: {}", server_id);
             // Return updated server list
             get_server_list(State(state)).await.into_response()

--- a/crates/jellyswarrm-proxy/src/ui/admin/servers.rs
+++ b/crates/jellyswarrm-proxy/src/ui/admin/servers.rs
@@ -11,6 +11,7 @@ use tracing::{error, info};
 use crate::{
     config::MediaStreamingMode,
     encryption::{encrypt_password, Password},
+    server_id::ServerId,
     server_storage::Server,
     AppState,
 };
@@ -183,8 +184,21 @@ pub async fn add_server(
         Err(e) => {
             error!("Failed to add server: {}", e);
 
-            let error_message = if e.to_string().contains("UNIQUE constraint failed") {
-                "A server with that name already exists"
+            let error_message = if let sqlx::Error::Database(db_error) = &e {
+                let constraint = db_error.constraint().unwrap_or_default();
+                let message = db_error.message();
+                if constraint == "idx_servers_url_unique"
+                    || message.contains("idx_servers_url_unique")
+                    || message.contains("servers.url")
+                {
+                    "A server with that URL already exists"
+                } else if message.contains("servers.name")
+                    || message.contains("UNIQUE constraint failed")
+                {
+                    "A server with that name already exists"
+                } else {
+                    "Failed to add server"
+                }
             } else if e.to_string().contains("Invalid URL") {
                 "Invalid URL format"
             } else {
@@ -205,7 +219,7 @@ pub async fn add_server(
 /// Update server media streaming mode
 pub async fn update_server_media_streaming_mode(
     State(state): State<AppState>,
-    Path(server_id): Path<i64>,
+    Path(server_id): Path<ServerId>,
     Form(form): Form<UpdateMediaStreamingModeForm>,
 ) -> Response {
     let media_streaming_mode = match form.media_streaming_mode.parse::<MediaStreamingMode>() {
@@ -248,7 +262,10 @@ pub async fn update_server_media_streaming_mode(
 }
 
 /// Delete a server
-pub async fn delete_server(State(state): State<AppState>, Path(server_id): Path<i64>) -> Response {
+pub async fn delete_server(
+    State(state): State<AppState>,
+    Path(server_id): Path<ServerId>,
+) -> Response {
     match state.server_storage.delete_server(server_id).await {
         Ok(true) => {
             info!("Deleted server with ID: {}", server_id);
@@ -274,7 +291,7 @@ pub async fn delete_server(State(state): State<AppState>, Path(server_id): Path<
 /// Update server priority
 pub async fn update_server_priority(
     State(state): State<AppState>,
-    Path(server_id): Path<i64>,
+    Path(server_id): Path<ServerId>,
     Form(form): Form<UpdatePriorityForm>,
 ) -> Response {
     if form.priority < 1 || form.priority > 999 {
@@ -314,7 +331,7 @@ pub async fn update_server_priority(
 /// Add server admin
 pub async fn add_server_admin(
     State(state): State<AppState>,
-    Path(server_id): Path<i64>,
+    Path(server_id): Path<ServerId>,
     Form(form): Form<AddServerAdminForm>,
 ) -> Response {
     // 1. Get server details
@@ -433,7 +450,7 @@ pub async fn add_server_admin(
 /// Delete server admin
 pub async fn delete_server_admin(
     State(state): State<AppState>,
-    Path(server_id): Path<i64>,
+    Path(server_id): Path<ServerId>,
 ) -> Response {
     match state.server_storage.delete_server_admin(server_id).await {
         Ok(true) => {

--- a/crates/jellyswarrm-proxy/src/ui/admin/users.rs
+++ b/crates/jellyswarrm-proxy/src/ui/admin/users.rs
@@ -11,10 +11,11 @@ use std::collections::HashMap;
 use tracing::{error, info};
 
 use crate::{
-    encryption::Password,
+    encryption::{HashedPassword, Password},
     federated_users::ServerSyncResult,
+    server_id::ServerId,
     server_storage::Server,
-    user_authorization_service::{ServerMapping, User},
+    user_authorization_service::{ServerMapping, User, UserAuthorizationService},
     AppState,
 };
 
@@ -57,9 +58,33 @@ pub struct AddUserForm {
 #[derive(Deserialize)]
 pub struct AddMappingForm {
     pub user_id: String,
-    pub server_url: String,
+    pub server_id: ServerId,
     pub mapped_username: String,
     pub mapped_password: Password,
+}
+
+fn mapping_credentials_changed(
+    user_authorization: &UserAuthorizationService,
+    previous_mapping: &ServerMapping,
+    user: &User,
+    admin_password_hash: &HashedPassword,
+    admin_password: &Password,
+    mapped_username: &str,
+    mapped_password: &Password,
+) -> bool {
+    let mapped_username_changed = !previous_mapping
+        .mapped_username
+        .trim()
+        .eq_ignore_ascii_case(mapped_username.trim());
+    let previous_password = user_authorization.decrypt_server_mapping_password(
+        previous_mapping,
+        &user.original_password_hash,
+        admin_password_hash,
+        None,
+        Some(admin_password),
+    );
+
+    mapped_username_changed || previous_password != *mapped_password
 }
 
 pub async fn create_user_with_mappings(
@@ -67,7 +92,7 @@ pub async fn create_user_with_mappings(
     user: User,
     servers: &[Server],
 ) -> UserWithMappings {
-    // session counts per server_url (normalized)
+    // Session counts keyed by canonical server URL for template display.
     let mut session_counts: HashMap<String, i64> = HashMap::new();
     if let Ok(rows) = state
         .user_authorization
@@ -84,20 +109,17 @@ pub async fn create_user_with_mappings(
         .list_server_mappings(&user.id)
         .await;
     let mut mappings_vec: Vec<(ServerMapping, Server, i64)> = Vec::new();
-    let mut mapped_urls: Vec<String> = Vec::new();
+    let mut mapped_server_ids: Vec<ServerId> = Vec::new();
     match mappings_fetch {
         Ok(mappings) => {
             for mapping in mappings {
-                if let Some(server) = servers.iter().find(|srv| {
-                    srv.url.as_str().trim_end_matches('/')
-                        == mapping.server_url.trim_end_matches('/')
-                }) {
+                if let Some(server) = servers.iter().find(|srv| srv.id == mapping.server_id) {
                     let count = session_counts
-                        .get(mapping.server_url.trim_end_matches('/'))
+                        .get(server.url.as_str())
                         .cloned()
                         .unwrap_or(0);
                     mappings_vec.push((mapping, server.clone(), count));
-                    mapped_urls.push(server.url.as_str().trim_end_matches('/').to_string());
+                    mapped_server_ids.push(server.id);
                 }
             }
         }
@@ -107,11 +129,7 @@ pub async fn create_user_with_mappings(
     }
     let available_servers: Vec<Server> = servers
         .iter()
-        .filter(|srv| {
-            !mapped_urls
-                .iter()
-                .any(|u| u == srv.url.as_str().trim_end_matches('/'))
-        })
+        .filter(|srv| !mapped_server_ids.contains(&srv.id))
         .cloned()
         .collect();
     let user_total_sessions: i64 = mappings_vec.iter().map(|(_, _, c)| *c).sum();
@@ -372,7 +390,7 @@ pub async fn add_mapping(
 
     info!(
         "Validating mapping credentials for local user '{}' on '{}' as mapped user '{}'.",
-        form.user_id, form.server_url, form.mapped_username
+        form.user_id, form.server_id, form.mapped_username
     );
 
     let all_servers = match state.server_storage.list_servers().await {
@@ -388,11 +406,7 @@ pub async fn add_mapping(
         }
     };
 
-    let normalized_target = form.server_url.trim_end_matches('/');
-    let server = match all_servers
-        .into_iter()
-        .find(|s| s.url.as_str().trim_end_matches('/') == normalized_target)
-    {
+    let server = match all_servers.into_iter().find(|s| s.id == form.server_id) {
         Some(server) => server,
         None => {
             return user_item_with_popup(
@@ -465,14 +479,14 @@ pub async fn add_mapping(
 
     let previous_mapping = match state
         .user_authorization
-        .get_server_mapping(&form.user_id, &form.server_url)
+        .get_server_mapping(&form.user_id, &server)
         .await
     {
         Ok(mapping) => mapping,
         Err(e) => {
             error!(
                 "Failed to load existing mapping for local user '{}' to server '{}': {}",
-                form.user_id, form.server_url, e
+                form.user_id, server.name, e
             );
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -482,40 +496,78 @@ pub async fn add_mapping(
         }
     };
 
-    let mapped_username_changed = previous_mapping.as_ref().is_some_and(|mapping| {
-        !mapping
-            .mapped_username
-            .trim()
-            .eq_ignore_ascii_case(form.mapped_username.trim())
-    });
+    let previous_mapping_user = if previous_mapping.is_some() {
+        match state.user_authorization.get_user_by_id(&form.user_id).await {
+            Ok(Some(user)) => Some(user),
+            Ok(None) => {
+                return user_item_with_popup(
+                    &state,
+                    &form.user_id,
+                    "Local user was not found. Please refresh and try again.".to_string(),
+                )
+                .await;
+            }
+            Err(e) => {
+                error!(
+                    "Failed to load local user '{}' while comparing mapping credentials: {}",
+                    form.user_id, e
+                );
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Html(
+                        "<div class=\"alert alert-error\">Failed to inspect existing mapping</div>",
+                    ),
+                )
+                    .into_response();
+            }
+        }
+    } else {
+        None
+    };
 
-    let config = state.config.read().await;
-    let admin_password = &config.password;
+    let admin_password = {
+        let config = state.config.read().await;
+        config.password.clone()
+    };
+    let admin_password_hash: HashedPassword = (&admin_password).into();
+
+    let mapped_credentials_changed = match (&previous_mapping, &previous_mapping_user) {
+        (Some(mapping), Some(user)) => mapping_credentials_changed(
+            &state.user_authorization,
+            mapping,
+            user,
+            &admin_password_hash,
+            &admin_password,
+            &form.mapped_username,
+            &form.mapped_password,
+        ),
+        _ => false,
+    };
 
     match state
         .user_authorization
         .add_server_mapping(
             &form.user_id,
-            &form.server_url,
+            &server,
             &form.mapped_username,
             &form.mapped_password,
-            Some(&admin_password.into()),
+            Some(&admin_password_hash),
         )
         .await
     {
         Ok(mapping_id) => {
             info!(
                 "Saved mapping {} for local user '{}' to server '{}' as mapped user '{}'.",
-                mapping_id, form.user_id, form.server_url, form.mapped_username
+                mapping_id, form.user_id, server.name, form.mapped_username
             );
-            if mapped_username_changed {
+            if mapped_credentials_changed {
                 match state
                     .user_authorization
                     .delete_sessions_for_mapping(mapping_id)
                     .await
                 {
                     Ok(deleted) => info!(
-                        "Mapped account changed for mapping {} (user {}). Deleted {} affected session(s)",
+                        "Mapped credentials changed for mapping {} (user {}). Deleted {} affected session(s)",
                         mapping_id, form.user_id, deleted
                     ),
                     Err(e) => error!(
@@ -529,7 +581,7 @@ pub async fn add_mapping(
         Err(e) => {
             error!(
                 "Failed to save mapping for local user '{}' to server '{}': {}",
-                form.user_id, form.server_url, e
+                form.user_id, server.name, e
             );
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -586,5 +638,83 @@ pub async fn delete_sessions(
             )
                 .into_response()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encryption::encrypt_password;
+    use sqlx::SqlitePool;
+
+    fn test_user() -> User {
+        let now = chrono::Utc::now();
+        User {
+            id: "user-id".to_string(),
+            virtual_key: "virtual-key".to_string(),
+            original_username: "local-user".to_string(),
+            original_password_hash: HashedPassword::from_password("local-password"),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn test_mapping(
+        mapped_password: Password,
+        admin_password_hash: &HashedPassword,
+    ) -> ServerMapping {
+        let now = chrono::Utc::now();
+        ServerMapping {
+            id: 1,
+            user_id: "user-id".to_string(),
+            server_id: ServerId::new(1),
+            server_url: "http://localhost:8096".to_string(),
+            mapped_username: "mapped-user".to_string(),
+            mapped_password: encrypt_password(&mapped_password, admin_password_hash).unwrap(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_mapping_credentials_changed_detects_password_only_change() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let service = UserAuthorizationService::new(pool);
+        let admin_password: Password = "admin-password".into();
+        let admin_password_hash: HashedPassword = (&admin_password).into();
+        let user = test_user();
+        let mapping = test_mapping("old-password".into(), &admin_password_hash);
+        let new_password: Password = "new-password".into();
+
+        assert!(mapping_credentials_changed(
+            &service,
+            &mapping,
+            &user,
+            &admin_password_hash,
+            &admin_password,
+            "mapped-user",
+            &new_password,
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_mapping_credentials_changed_ignores_unchanged_credentials() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let service = UserAuthorizationService::new(pool);
+        let admin_password: Password = "admin-password".into();
+        let admin_password_hash: HashedPassword = (&admin_password).into();
+        let user = test_user();
+        let same_password: Password = "old-password".into();
+        let mapping = test_mapping(same_password.clone(), &admin_password_hash);
+
+        assert!(!mapping_credentials_changed(
+            &service,
+            &mapping,
+            &user,
+            &admin_password_hash,
+            &admin_password,
+            " mapped-user ",
+            &same_password,
+        ));
     }
 }

--- a/crates/jellyswarrm-proxy/src/ui/admin/users.rs
+++ b/crates/jellyswarrm-proxy/src/ui/admin/users.rs
@@ -11,11 +11,11 @@ use std::collections::HashMap;
 use tracing::{error, info};
 
 use crate::{
-    encryption::{HashedPassword, Password},
+    encryption::Password,
     federated_users::ServerSyncResult,
     server_id::ServerId,
     server_storage::Server,
-    user_authorization_service::{ServerMapping, User, UserAuthorizationService},
+    user_authorization_service::{ServerMapping, User},
     AppState,
 };
 
@@ -61,30 +61,6 @@ pub struct AddMappingForm {
     pub server_id: ServerId,
     pub mapped_username: String,
     pub mapped_password: Password,
-}
-
-fn mapping_credentials_changed(
-    user_authorization: &UserAuthorizationService,
-    previous_mapping: &ServerMapping,
-    user: &User,
-    admin_password_hash: &HashedPassword,
-    admin_password: &Password,
-    mapped_username: &str,
-    mapped_password: &Password,
-) -> bool {
-    let mapped_username_changed = !previous_mapping
-        .mapped_username
-        .trim()
-        .eq_ignore_ascii_case(mapped_username.trim());
-    let previous_password = user_authorization.decrypt_server_mapping_password(
-        previous_mapping,
-        &user.original_password_hash,
-        admin_password_hash,
-        None,
-        Some(admin_password),
-    );
-
-    mapped_username_changed || previous_password != *mapped_password
 }
 
 pub async fn create_user_with_mappings(
@@ -477,71 +453,9 @@ pub async fn add_mapping(
         }
     }
 
-    let previous_mapping = match state
-        .user_authorization
-        .get_server_mapping(&form.user_id, &server)
-        .await
-    {
-        Ok(mapping) => mapping,
-        Err(e) => {
-            error!(
-                "Failed to load existing mapping for local user '{}' to server '{}': {}",
-                form.user_id, server.name, e
-            );
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Html("<div class=\"alert alert-error\">Failed to inspect existing mapping</div>"),
-            )
-                .into_response();
-        }
-    };
-
-    let previous_mapping_user = if previous_mapping.is_some() {
-        match state.user_authorization.get_user_by_id(&form.user_id).await {
-            Ok(Some(user)) => Some(user),
-            Ok(None) => {
-                return user_item_with_popup(
-                    &state,
-                    &form.user_id,
-                    "Local user was not found. Please refresh and try again.".to_string(),
-                )
-                .await;
-            }
-            Err(e) => {
-                error!(
-                    "Failed to load local user '{}' while comparing mapping credentials: {}",
-                    form.user_id, e
-                );
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Html(
-                        "<div class=\"alert alert-error\">Failed to inspect existing mapping</div>",
-                    ),
-                )
-                    .into_response();
-            }
-        }
-    } else {
-        None
-    };
-
     let admin_password = {
         let config = state.config.read().await;
-        config.password.clone()
-    };
-    let admin_password_hash: HashedPassword = (&admin_password).into();
-
-    let mapped_credentials_changed = match (&previous_mapping, &previous_mapping_user) {
-        (Some(mapping), Some(user)) => mapping_credentials_changed(
-            &state.user_authorization,
-            mapping,
-            user,
-            &admin_password_hash,
-            &admin_password,
-            &form.mapped_username,
-            &form.mapped_password,
-        ),
-        _ => false,
+        (&config.password).into()
     };
 
     match state
@@ -551,7 +465,7 @@ pub async fn add_mapping(
             &server,
             &form.mapped_username,
             &form.mapped_password,
-            Some(&admin_password_hash),
+            Some(&admin_password),
         )
         .await
     {
@@ -560,22 +474,6 @@ pub async fn add_mapping(
                 "Saved mapping {} for local user '{}' to server '{}' as mapped user '{}'.",
                 mapping_id, form.user_id, server.name, form.mapped_username
             );
-            if mapped_credentials_changed {
-                match state
-                    .user_authorization
-                    .delete_sessions_for_mapping(mapping_id)
-                    .await
-                {
-                    Ok(deleted) => info!(
-                        "Mapped credentials changed for mapping {} (user {}). Deleted {} affected session(s)",
-                        mapping_id, form.user_id, deleted
-                    ),
-                    Err(e) => error!(
-                        "Failed to delete sessions for changed mapping {} (user {}): {}",
-                        mapping_id, form.user_id, e
-                    ),
-                }
-            }
             get_user_item(&state, &form.user_id).await.into_response()
         }
         Err(e) => {
@@ -638,83 +536,5 @@ pub async fn delete_sessions(
             )
                 .into_response()
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::encryption::encrypt_password;
-    use sqlx::SqlitePool;
-
-    fn test_user() -> User {
-        let now = chrono::Utc::now();
-        User {
-            id: "user-id".to_string(),
-            virtual_key: "virtual-key".to_string(),
-            original_username: "local-user".to_string(),
-            original_password_hash: HashedPassword::from_password("local-password"),
-            created_at: now,
-            updated_at: now,
-        }
-    }
-
-    fn test_mapping(
-        mapped_password: Password,
-        admin_password_hash: &HashedPassword,
-    ) -> ServerMapping {
-        let now = chrono::Utc::now();
-        ServerMapping {
-            id: 1,
-            user_id: "user-id".to_string(),
-            server_id: ServerId::new(1),
-            server_url: "http://localhost:8096".to_string(),
-            mapped_username: "mapped-user".to_string(),
-            mapped_password: encrypt_password(&mapped_password, admin_password_hash).unwrap(),
-            created_at: now,
-            updated_at: now,
-        }
-    }
-
-    #[tokio::test]
-    async fn test_mapping_credentials_changed_detects_password_only_change() {
-        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-        let service = UserAuthorizationService::new(pool);
-        let admin_password: Password = "admin-password".into();
-        let admin_password_hash: HashedPassword = (&admin_password).into();
-        let user = test_user();
-        let mapping = test_mapping("old-password".into(), &admin_password_hash);
-        let new_password: Password = "new-password".into();
-
-        assert!(mapping_credentials_changed(
-            &service,
-            &mapping,
-            &user,
-            &admin_password_hash,
-            &admin_password,
-            "mapped-user",
-            &new_password,
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_mapping_credentials_changed_ignores_unchanged_credentials() {
-        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-        let service = UserAuthorizationService::new(pool);
-        let admin_password: Password = "admin-password".into();
-        let admin_password_hash: HashedPassword = (&admin_password).into();
-        let user = test_user();
-        let same_password: Password = "old-password".into();
-        let mapping = test_mapping(same_password.clone(), &admin_password_hash);
-
-        assert!(!mapping_credentials_changed(
-            &service,
-            &mapping,
-            &user,
-            &admin_password_hash,
-            &admin_password,
-            " mapped-user ",
-            &same_password,
-        ));
     }
 }

--- a/crates/jellyswarrm-proxy/src/ui/server_status.rs
+++ b/crates/jellyswarrm-proxy/src/ui/server_status.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use tracing::error;
 
-use crate::{server_storage::ServerHealthStatus, AppState};
+use crate::{server_id::ServerId, server_storage::ServerHealthStatus, AppState};
 
 #[derive(Template)]
 #[template(path = "admin/server_status.html")]
@@ -18,7 +18,7 @@ pub struct ServerStatusTemplate {
 /// Check server status
 pub async fn check_server_status(
     State(state): State<AppState>,
-    Path(server_id): Path<i64>,
+    Path(server_id): Path<ServerId>,
 ) -> impl IntoResponse {
     // Get the server details first
     match state.server_storage.get_server_by_id(server_id).await {

--- a/crates/jellyswarrm-proxy/src/ui/templates/admin/user_item.html
+++ b/crates/jellyswarrm-proxy/src/ui/templates/admin/user_item.html
@@ -35,10 +35,10 @@
             <input type="hidden" name="user_id" value="{{ uwm.user.id }}">
             <div class="grid" style="--pico-grid-gap:1rem; align-items:end;">
                 <label>Server
-                    <select id="server-{{ uwm.user.id }}" name="server_url" required style="margin-bottom:0;">
+                    <select id="server-{{ uwm.user.id }}" name="server_id" required style="margin-bottom:0;">
                         <option value="" disabled selected>Select server</option>
                         {% for server in uwm.available_servers %}
-                        <option value="{{ server.url }}">{{ server.name }}</option>
+                        <option value="{{ server.id }}">{{ server.name }}</option>
                         {% endfor %}
                     </select>
                 </label>

--- a/crates/jellyswarrm-proxy/src/ui/user/common.rs
+++ b/crates/jellyswarrm-proxy/src/ui/user/common.rs
@@ -39,7 +39,7 @@ pub async fn authenticate_user_on_server(
     // Check for mapping and try to authenticate
     let mapping = match state
         .user_authorization
-        .get_server_mapping(&user.id, server.url.as_str())
+        .get_server_mapping(&user.id, server)
         .await
     {
         Ok(Some(m)) => m,

--- a/crates/jellyswarrm-proxy/src/ui/user/media.rs
+++ b/crates/jellyswarrm-proxy/src/ui/user/media.rs
@@ -9,12 +9,13 @@ use jellyfin_api::models::{BaseItem, IncludeItemTypes};
 use tracing::error;
 
 use crate::{
+    server_id::ServerId,
     ui::{auth::AuthenticatedUser, user::common::authenticate_user_on_server},
     AppState,
 };
 
 pub struct ServerInfo {
-    pub id: i64,
+    pub id: ServerId,
     pub name: String,
 }
 
@@ -34,7 +35,7 @@ pub struct UserMediaTemplate {
 #[derive(Template)]
 #[template(path = "user/server_libraries.html")]
 pub struct ServerLibrariesTemplate {
-    pub server_id: i64,
+    pub server_id: ServerId,
     pub libraries: Vec<LibraryWithCount>,
     pub ui_route: String,
 }
@@ -42,7 +43,7 @@ pub struct ServerLibrariesTemplate {
 #[derive(Template)]
 #[template(path = "user/library_items.html")]
 pub struct LibraryItemsTemplate {
-    pub server_id: i64,
+    pub server_id: ServerId,
     pub library_id: String,
     pub items: Vec<BaseItem>,
     pub next_page: Option<i32>,
@@ -90,7 +91,7 @@ pub async fn get_user_media(
 pub async fn get_server_libraries(
     State(state): State<AppState>,
     AuthenticatedUser(user): AuthenticatedUser,
-    Path(server_id): Path<i64>,
+    Path(server_id): Path<ServerId>,
 ) -> impl IntoResponse {
     let server = match state.server_storage.get_server_by_id(server_id).await {
         Ok(Some(s)) => s,
@@ -161,7 +162,7 @@ pub async fn get_server_libraries(
 pub async fn get_library_items(
     State(state): State<AppState>,
     AuthenticatedUser(user): AuthenticatedUser,
-    Path((server_id, library_id)): Path<(i64, String)>,
+    Path((server_id, library_id)): Path<(ServerId, String)>,
     Query(pagination): Query<Pagination>,
 ) -> impl IntoResponse {
     let server = match state.server_storage.get_server_by_id(server_id).await {
@@ -228,7 +229,7 @@ pub async fn get_library_items(
 pub async fn proxy_media_image(
     State(state): State<AppState>,
     AuthenticatedUser(user): AuthenticatedUser,
-    Path((server_id, item_id)): Path<(i64, String)>,
+    Path((server_id, item_id)): Path<(ServerId, String)>,
 ) -> impl IntoResponse {
     // Get server
     let server = match state.server_storage.get_server_by_id(server_id).await {

--- a/crates/jellyswarrm-proxy/src/ui/user/servers.rs
+++ b/crates/jellyswarrm-proxy/src/ui/user/servers.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use tracing::{error, info};
 
 use crate::{
-    encryption::{HashedPassword, Password},
+    encryption::Password,
     server_id::ServerId,
     server_storage::Server,
     ui::{auth::AuthenticatedUser, user::common::authenticate_user_on_server},
@@ -126,43 +126,6 @@ pub async fn connect_server(
 
     match client.authenticate_by_name(&form.username, form.password.as_str()).await {
         Ok(_) => {
-            let previous_mapping = match state
-                .user_authorization
-                .get_server_mapping(&user.id, &server)
-                .await
-            {
-                Ok(mapping) => mapping,
-                Err(e) => {
-                    error!("Failed to inspect existing mapping: {}", e);
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Html("<span style=\"color: #dc3545;\">Database error</span>"),
-                    )
-                        .into_response();
-                }
-            };
-
-            let admin_password = {
-                let config = state.config.read().await;
-                config.password.clone()
-            };
-            let admin_password_hash: HashedPassword = (&admin_password).into();
-            let mapped_credentials_changed = previous_mapping.as_ref().is_some_and(|mapping| {
-                let mapped_username_changed = !mapping
-                    .mapped_username
-                    .trim()
-                    .eq_ignore_ascii_case(form.username.trim());
-                let previous_password = state.user_authorization.decrypt_server_mapping_password(
-                    mapping,
-                    &user.password_hash,
-                    &admin_password_hash,
-                    None,
-                    Some(&admin_password),
-                );
-
-                mapped_username_changed || previous_password != form.password
-            });
-
             // Credentials valid, create mapping
             match state
                 .user_authorization
@@ -175,24 +138,7 @@ pub async fn connect_server(
                 )
                 .await
             {
-                Ok(mapping_id) => {
-                    if mapped_credentials_changed {
-                        match state
-                            .user_authorization
-                            .delete_sessions_for_mapping(mapping_id)
-                            .await
-                        {
-                            Ok(deleted) => info!(
-                                "Mapped credentials changed for user {} on server {}. Deleted {} affected session(s)",
-                                user.username, server.name, deleted
-                            ),
-                            Err(e) => error!(
-                                "Failed to delete sessions for updated mapping {}: {}",
-                                mapping_id, e
-                            ),
-                        }
-                    }
-
+                Ok(_) => {
                     info!(
                         "Created mapping for user {} to server {}",
                         user.username, server.name
@@ -205,15 +151,15 @@ pub async fn connect_server(
                         HeaderValue::from_str(&format!("/{}", state.get_ui_route().await)).unwrap(),
                     );
                     response
-                },
-                 Err(e) => {
-                     error!("Failed to create mapping: {}", e);
-                     (
-                         StatusCode::OK,
-                         Html("<div style=\"background-color: #e74c3c; color: white; padding: 0.75rem; border-radius: 0.25rem; margin-bottom: 1rem;\">Database error</div>"),
-                     )
-                         .into_response()
-                 }
+                }
+                Err(e) => {
+                    error!("Failed to create mapping: {}", e);
+                    (
+                        StatusCode::OK,
+                        Html("<div style=\"background-color: #e74c3c; color: white; padding: 0.75rem; border-radius: 0.25rem; margin-bottom: 1rem;\">Database error</div>"),
+                    )
+                        .into_response()
+                }
             }
         }
         Err(jellyfin_api::error::Error::AuthenticationFailed(_)) => {

--- a/crates/jellyswarrm-proxy/src/ui/user/servers.rs
+++ b/crates/jellyswarrm-proxy/src/ui/user/servers.rs
@@ -10,7 +10,8 @@ use serde::Deserialize;
 use tracing::{error, info};
 
 use crate::{
-    encryption::Password,
+    encryption::{HashedPassword, Password},
+    server_id::ServerId,
     server_storage::Server,
     ui::{auth::AuthenticatedUser, user::common::authenticate_user_on_server},
     AppState,
@@ -83,7 +84,7 @@ pub async fn get_user_servers(
 pub async fn connect_server(
     State(state): State<AppState>,
     AuthenticatedUser(user): AuthenticatedUser,
-    Path(server_id): Path<i64>,
+    Path(server_id): Path<ServerId>,
     Form(form): Form<ConnectServerForm>,
 ) -> impl IntoResponse {
     // Get server details
@@ -127,7 +128,7 @@ pub async fn connect_server(
         Ok(_) => {
             let previous_mapping = match state
                 .user_authorization
-                .get_server_mapping(&user.id, server.url.as_str())
+                .get_server_mapping(&user.id, &server)
                 .await
             {
                 Ok(mapping) => mapping,
@@ -141,11 +142,25 @@ pub async fn connect_server(
                 }
             };
 
-            let mapped_username_changed = previous_mapping.as_ref().is_some_and(|mapping| {
-                !mapping
+            let admin_password = {
+                let config = state.config.read().await;
+                config.password.clone()
+            };
+            let admin_password_hash: HashedPassword = (&admin_password).into();
+            let mapped_credentials_changed = previous_mapping.as_ref().is_some_and(|mapping| {
+                let mapped_username_changed = !mapping
                     .mapped_username
                     .trim()
-                    .eq_ignore_ascii_case(form.username.trim())
+                    .eq_ignore_ascii_case(form.username.trim());
+                let previous_password = state.user_authorization.decrypt_server_mapping_password(
+                    mapping,
+                    &user.password_hash,
+                    &admin_password_hash,
+                    None,
+                    Some(&admin_password),
+                );
+
+                mapped_username_changed || previous_password != form.password
             });
 
             // Credentials valid, create mapping
@@ -153,7 +168,7 @@ pub async fn connect_server(
                 .user_authorization
                 .add_server_mapping(
                     &user.id,
-                    server.url.as_str(),
+                    &server,
                     &form.username,
                     &form.password,
                     Some(&user.password_hash),
@@ -161,14 +176,14 @@ pub async fn connect_server(
                 .await
             {
                 Ok(mapping_id) => {
-                    if mapped_username_changed {
+                    if mapped_credentials_changed {
                         match state
                             .user_authorization
                             .delete_sessions_for_mapping(mapping_id)
                             .await
                         {
                             Ok(deleted) => info!(
-                                "Mapped account changed for user {} on server {}. Deleted {} affected session(s)",
+                                "Mapped credentials changed for user {} on server {}. Deleted {} affected session(s)",
                                 user.username, server.name, deleted
                             ),
                             Err(e) => error!(
@@ -222,7 +237,7 @@ pub async fn connect_server(
 pub async fn delete_server_mapping(
     State(state): State<AppState>,
     AuthenticatedUser(user): AuthenticatedUser,
-    Path(server_id): Path<i64>,
+    Path(server_id): Path<ServerId>,
 ) -> impl IntoResponse {
     // Get server details to find the URL
     let server = match state.server_storage.get_server_by_id(server_id).await {
@@ -248,12 +263,7 @@ pub async fn delete_server_mapping(
     };
 
     // Normalize URLs for comparison (remove trailing slashes)
-    let server_url = server.url.as_str().trim_end_matches('/');
-
-    if let Some(mapping) = mappings
-        .iter()
-        .find(|m| m.server_url.trim_end_matches('/') == server_url)
-    {
+    if let Some(mapping) = mappings.iter().find(|m| m.server_id == server.id) {
         match state
             .user_authorization
             .delete_server_mapping(mapping.id)
@@ -285,7 +295,7 @@ pub async fn delete_server_mapping(
 pub async fn check_user_server_status(
     State(state): State<AppState>,
     AuthenticatedUser(user): AuthenticatedUser,
-    Path(server_id): Path<i64>,
+    Path(server_id): Path<ServerId>,
 ) -> impl IntoResponse {
     // Get server details
     let server = match state.server_storage.get_server_by_id(server_id).await {

--- a/crates/jellyswarrm-proxy/src/user_authorization_service.rs
+++ b/crates/jellyswarrm-proxy/src/user_authorization_service.rs
@@ -1,4 +1,4 @@
-use sqlx::{FromRow, Row, SqlitePool};
+use sqlx::{sqlite::SqliteRow, FromRow, Row, SqlitePool};
 use tracing::{debug, error, info, warn};
 
 use crate::config::MediaStreamingMode;
@@ -7,7 +7,10 @@ use crate::encryption::{
     HashedPassword, Password,
 };
 use crate::models::{generate_token, Authorization};
-use crate::server_storage::Server;
+use crate::server_id::ServerId;
+use crate::server_storage::{parse_server_url_column, Server};
+#[cfg(test)]
+use crate::server_url::ServerUrl;
 
 #[derive(Debug, Clone, FromRow, Eq, PartialEq, Hash)]
 pub struct User {
@@ -19,15 +22,31 @@ pub struct User {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Debug, Clone, FromRow)]
+#[derive(Debug, Clone)]
 pub struct ServerMapping {
     pub id: i64,
     pub user_id: String,
+    pub server_id: ServerId,
     pub server_url: String,
     pub mapped_username: String,
     pub mapped_password: EncryptedPassword,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl<'r> sqlx::FromRow<'r, SqliteRow> for ServerMapping {
+    fn from_row(row: &SqliteRow) -> Result<Self, sqlx::Error> {
+        Ok(Self {
+            id: row.try_get("id")?,
+            user_id: row.try_get("user_id")?,
+            server_id: ServerId::new(row.try_get("server_id")?),
+            server_url: row.try_get("server_url")?,
+            mapped_username: row.try_get("mapped_username")?,
+            mapped_password: row.try_get("mapped_password")?,
+            created_at: row.try_get("created_at")?,
+            updated_at: row.try_get("updated_at")?,
+        })
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -43,9 +62,6 @@ pub struct AuthorizationSession {
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
-
-// Manual implementation of FromRow for AuthorizationSession to support nested Device
-use sqlx::sqlite::SqliteRow;
 
 impl<'r> sqlx::FromRow<'r, SqliteRow> for AuthorizationSession {
     fn from_row(row: &SqliteRow) -> Result<Self, sqlx::Error> {
@@ -224,6 +240,33 @@ pub struct UserAuthorizationService {
     pool: SqlitePool,
 }
 
+#[cfg(test)]
+pub enum ServerReference<'a> {
+    Server(&'a Server),
+    Url(&'a str),
+}
+
+#[cfg(test)]
+impl<'a> From<&'a Server> for ServerReference<'a> {
+    fn from(server: &'a Server) -> Self {
+        Self::Server(server)
+    }
+}
+
+#[cfg(test)]
+impl<'a> From<&'a str> for ServerReference<'a> {
+    fn from(server_url: &'a str) -> Self {
+        Self::Url(server_url)
+    }
+}
+
+#[cfg(test)]
+impl<'a> From<&'a &'a str> for ServerReference<'a> {
+    fn from(server_url: &'a &'a str) -> Self {
+        Self::Url(server_url)
+    }
+}
+
 impl UserAuthorizationService {
     pub fn new(pool: SqlitePool) -> Self {
         Self { pool }
@@ -231,6 +274,34 @@ impl UserAuthorizationService {
 
     fn normalized_username_key(username: &str) -> String {
         username.trim().to_string()
+    }
+
+    #[cfg(test)]
+    async fn resolve_server_reference(
+        &self,
+        server: ServerReference<'_>,
+    ) -> Result<(ServerId, String), sqlx::Error> {
+        match server {
+            ServerReference::Server(server) => Ok((server.id, server.url.as_str().to_string())),
+            ServerReference::Url(server_url) => {
+                let server_url = ServerUrl::canonicalize(server_url)
+                    .unwrap_or_else(|_| server_url.trim().trim_end_matches('/').to_string());
+                let server_id = sqlx::query_scalar::<_, i64>(
+                    r#"
+                    SELECT id
+                    FROM servers
+                    WHERE RTRIM(url, '/') = ?
+                    ORDER BY id ASC
+                    LIMIT 1
+                    "#,
+                )
+                .bind(&server_url)
+                .fetch_one(&self.pool)
+                .await?;
+
+                Ok((ServerId::new(server_id), server_url))
+            }
+        }
     }
 
     /// Create or get a user by username.
@@ -414,9 +485,54 @@ impl UserAuthorizationService {
     }
 
     /// Add or update server mapping for a user
+    #[cfg(not(test))]
     pub async fn add_server_mapping(
         &self,
         user_id: &str,
+        server: &Server,
+        mapped_username: &str,
+        mapped_password: &Password,
+        master_password: Option<&HashedPassword>,
+    ) -> Result<i64, sqlx::Error> {
+        self.add_server_mapping_by_id(
+            user_id,
+            server.id,
+            server.url.as_str(),
+            mapped_username,
+            mapped_password,
+            master_password,
+        )
+        .await
+    }
+
+    #[cfg(test)]
+    pub async fn add_server_mapping<'a, S>(
+        &self,
+        user_id: &str,
+        server: S,
+        mapped_username: &str,
+        mapped_password: &Password,
+        master_password: Option<&HashedPassword>,
+    ) -> Result<i64, sqlx::Error>
+    where
+        S: Into<ServerReference<'a>>,
+    {
+        let (server_id, server_url) = self.resolve_server_reference(server.into()).await?;
+        self.add_server_mapping_by_id(
+            user_id,
+            server_id,
+            &server_url,
+            mapped_username,
+            mapped_password,
+            master_password,
+        )
+        .await
+    }
+
+    async fn add_server_mapping_by_id(
+        &self,
+        user_id: &str,
+        server_id: ServerId,
         server_url: &str,
         mapped_username: &str,
         mapped_password: &Password,
@@ -424,7 +540,9 @@ impl UserAuthorizationService {
     ) -> Result<i64, sqlx::Error> {
         let now = chrono::Utc::now();
 
-        let existing_mapping = self.get_server_mapping(user_id, server_url).await?;
+        let existing_mapping = self
+            .get_server_mapping_by_server_id(user_id, server_id)
+            .await?;
 
         let final_password = if let Some(master) = master_password {
             match encrypt_password(mapped_password, master) {
@@ -439,35 +557,26 @@ impl UserAuthorizationService {
             EncryptedPassword::from_raw(mapped_password.as_str().into())
         };
 
-        sqlx::query(
+        let mapping_id = sqlx::query_scalar::<_, i64>(
             r#"
             INSERT INTO server_mappings
-            (user_id, server_url, mapped_username, mapped_password, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?)
-            ON CONFLICT(user_id, server_url) DO UPDATE SET
+            (user_id, server_id, server_url, mapped_username, mapped_password, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(user_id, server_id) DO UPDATE SET
+                server_url = excluded.server_url,
                 mapped_username = excluded.mapped_username,
                 mapped_password = excluded.mapped_password,
                 updated_at = excluded.updated_at
+            RETURNING id
             "#,
         )
         .bind(user_id)
-        .bind(server_url)
+        .bind(server_id.as_i64())
+        .bind(&server_url)
         .bind(mapped_username)
         .bind(final_password)
         .bind(now)
         .bind(now)
-        .execute(&self.pool)
-        .await?;
-
-        let mapping_id = sqlx::query_scalar::<_, i64>(
-            r#"
-            SELECT id
-            FROM server_mappings
-            WHERE user_id = ? AND server_url = ?
-            "#,
-        )
-        .bind(user_id)
-        .bind(server_url)
         .fetch_one(&self.pool)
         .await?;
 
@@ -545,17 +654,26 @@ impl UserAuthorizationService {
     pub async fn get_server_mapping(
         &self,
         user_id: &str,
-        server_url: &str,
+        server: &Server,
+    ) -> Result<Option<ServerMapping>, sqlx::Error> {
+        self.get_server_mapping_by_server_id(user_id, server.id)
+            .await
+    }
+
+    pub async fn get_server_mapping_by_server_id(
+        &self,
+        user_id: &str,
+        server_id: ServerId,
     ) -> Result<Option<ServerMapping>, sqlx::Error> {
         let mapping = sqlx::query_as::<_, ServerMapping>(
             r#"
-            SELECT id, user_id, server_url, mapped_username, mapped_password, created_at, updated_at
+            SELECT id, user_id, server_id, server_url, mapped_username, mapped_password, created_at, updated_at
             FROM server_mappings
-            WHERE user_id = ? AND server_url = ?
+            WHERE user_id = ? AND server_id = ?
             "#,
         )
         .bind(user_id)
-        .bind(server_url)
+        .bind(server_id.as_i64())
         .fetch_optional(&self.pool)
         .await?;
 
@@ -569,7 +687,7 @@ impl UserAuthorizationService {
     ) -> Result<Vec<ServerMapping>, sqlx::Error> {
         let mappings = sqlx::query_as::<_, ServerMapping>(
             r#"
-            SELECT id, user_id, server_url, mapped_username, mapped_password, created_at, updated_at
+            SELECT id, user_id, server_id, server_url, mapped_username, mapped_password, created_at, updated_at
             FROM server_mappings
             WHERE user_id = ?
             ORDER BY server_url
@@ -583,9 +701,58 @@ impl UserAuthorizationService {
     }
 
     /// Store authorization session
+    #[cfg(not(test))]
     pub async fn store_authorization_session(
         &self,
         user_id: &str,
+        server: &Server,
+        authorization: &Authorization,
+        jellyfin_token: String,
+        original_user_id: String,
+        expires_at: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<i64, sqlx::Error> {
+        self.store_authorization_session_by_id(
+            user_id,
+            server.id,
+            server.url.as_str(),
+            authorization,
+            jellyfin_token,
+            original_user_id,
+            expires_at,
+        )
+        .await
+    }
+
+    #[cfg(test)]
+    pub async fn store_authorization_session<'a, S>(
+        &self,
+        user_id: &str,
+        server: S,
+        authorization: &Authorization,
+        jellyfin_token: String,
+        original_user_id: String,
+        expires_at: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<i64, sqlx::Error>
+    where
+        S: Into<ServerReference<'a>>,
+    {
+        let (server_id, server_url) = self.resolve_server_reference(server.into()).await?;
+        self.store_authorization_session_by_id(
+            user_id,
+            server_id,
+            &server_url,
+            authorization,
+            jellyfin_token,
+            original_user_id,
+            expires_at,
+        )
+        .await
+    }
+
+    async fn store_authorization_session_by_id(
+        &self,
+        user_id: &str,
+        server_id: ServerId,
         server_url: &str,
         authorization: &Authorization,
         jellyfin_token: String,
@@ -596,20 +763,30 @@ impl UserAuthorizationService {
 
         // Find mapping to obtain mapping_id (required for referential integrity & cascade deletes)
         let mapping = self
-            .get_server_mapping(user_id, server_url)
+            .get_server_mapping_by_server_id(user_id, server_id)
             .await?
             .ok_or(sqlx::Error::RowNotFound)?;
 
-        let result = sqlx::query(
+        let session_id = sqlx::query_scalar::<_, i64>(
             r#"
-            INSERT OR REPLACE INTO authorization_sessions
+            INSERT INTO authorization_sessions
             (user_id, mapping_id, server_url, client, device, device_id, version, jellyfin_token, original_user_id, expires_at, created_at, updated_at)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(user_id, mapping_id, device_id) DO UPDATE SET
+                server_url = excluded.server_url,
+                client = excluded.client,
+                device = excluded.device,
+                version = excluded.version,
+                jellyfin_token = excluded.jellyfin_token,
+                original_user_id = excluded.original_user_id,
+                expires_at = excluded.expires_at,
+                updated_at = excluded.updated_at
+            RETURNING id
             "#,
         )
         .bind(user_id)
         .bind(mapping.id)
-        .bind(server_url)
+        .bind(&server_url)
         .bind(&authorization.client)
         .bind(&authorization.device)
         .bind(&authorization.device_id)
@@ -619,10 +796,9 @@ impl UserAuthorizationService {
         .bind(expires_at)
         .bind(now)
         .bind(now)
-        .execute(&self.pool)
+        .fetch_one(&self.pool)
         .await?;
 
-        let session_id = result.last_insert_rowid();
         info!(
             "Stored authorization session for user {} on server {}",
             user_id, server_url
@@ -683,7 +859,7 @@ impl UserAuthorizationService {
         auth.id as auth_id,
         auth.user_id as auth_user_id,
         auth.mapping_id as auth_mapping_id,
-        auth.server_url as auth_server_url,
+        sm.server_url as auth_server_url,
         auth.client,
         auth.device,
         auth.device_id,
@@ -702,7 +878,8 @@ impl UserAuthorizationService {
         s.created_at as server_created_at,
         s.updated_at as server_updated_at
     FROM authorization_sessions auth
-    JOIN servers s ON RTRIM(auth.server_url, '/') = RTRIM(s.url, '/')
+    JOIN server_mappings sm ON auth.mapping_id = sm.id
+    JOIN servers s ON sm.server_id = s.id
     WHERE auth.user_id = ?
     AND (auth.expires_at IS NULL OR auth.expires_at > ?)
     ORDER BY s.priority DESC, s.name ASC
@@ -738,9 +915,9 @@ impl UserAuthorizationService {
                 };
 
                 let server = Server {
-                    id: row.get("server_id"),
+                    id: ServerId::new(row.get("server_id")),
                     name: row.get("server_name"),
-                    url: url::Url::parse(row.get::<String, _>("server_url_full").as_str()).unwrap(),
+                    url: parse_server_url_column("server_url_full", row.get("server_url_full"))?,
                     priority: row.get("priority"),
                     media_streaming_mode: row
                         .get::<String, _>("media_streaming_mode")
@@ -750,9 +927,9 @@ impl UserAuthorizationService {
                     updated_at: row.get("server_updated_at"),
                 };
 
-                (auth_session, server)
+                Ok((auth_session, server))
             })
-            .collect();
+            .collect::<Result<_, sqlx::Error>>()?;
 
         debug!("Found {} sessions for user_id: {}", sessions.len(), user_id);
 
@@ -945,10 +1122,20 @@ impl UserAuthorizationService {
 
     /// Delete a server mapping
     pub async fn delete_server_mapping(&self, mapping_id: i64) -> Result<bool, sqlx::Error> {
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query("DELETE FROM authorization_sessions WHERE mapping_id = ?")
+            .bind(mapping_id)
+            .execute(&mut *tx)
+            .await?;
+
         let res = sqlx::query("DELETE FROM server_mappings WHERE id = ?")
             .bind(mapping_id)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
+
+        tx.commit().await?;
+
         Ok(res.rows_affected() > 0)
     }
 
@@ -986,7 +1173,7 @@ impl UserAuthorizationService {
         // 2. Re-encrypt all server mappings
         let mappings = sqlx::query_as::<_, ServerMapping>(
             r#"
-            SELECT id, user_id, server_url, mapped_username, mapped_password, created_at, updated_at
+            SELECT id, user_id, server_id, server_url, mapped_username, mapped_password, created_at, updated_at
             FROM server_mappings
             WHERE user_id = ?
             "#,
@@ -1053,16 +1240,18 @@ impl UserAuthorizationService {
         }
     }
 
-    /// Get counts of authorization sessions per normalized server URL for a user
+    /// Get counts of authorization sessions per server for a user.
     pub async fn session_counts_by_server(
         &self,
         user_id: &str,
     ) -> Result<Vec<(String, i64)>, sqlx::Error> {
         let rows = sqlx::query(
-            r#"SELECT RTRIM(server_url,'/') as url_norm, COUNT(*) as cnt
-                FROM authorization_sessions
-                WHERE user_id = ?
-                GROUP BY url_norm"#,
+            r#"SELECT s.url as url_norm, COUNT(*) as cnt
+                FROM authorization_sessions auth
+                JOIN server_mappings sm ON auth.mapping_id = sm.id
+                JOIN servers s ON sm.server_id = s.id
+                WHERE auth.user_id = ?
+                GROUP BY sm.server_id"#,
         )
         .bind(user_id)
         .fetch_all(&self.pool)
@@ -1073,12 +1262,14 @@ impl UserAuthorizationService {
             .collect())
     }
 
-    /// Aggregate session counts for all users (user_id, server_url_normalized, count)
+    /// Aggregate session counts for all users (user_id, canonical server URL, count).
     pub async fn all_session_counts(&self) -> Result<Vec<(String, String, i64)>, sqlx::Error> {
         let rows = sqlx::query(
-            r#"SELECT user_id, RTRIM(server_url,'/') as url_norm, COUNT(*) as cnt
-                FROM authorization_sessions
-                GROUP BY user_id, url_norm"#,
+            r#"SELECT auth.user_id, s.url as url_norm, COUNT(*) as cnt
+                FROM authorization_sessions auth
+                JOIN server_mappings sm ON auth.mapping_id = sm.id
+                JOIN servers s ON sm.server_id = s.id
+                GROUP BY auth.user_id, sm.server_id"#,
         )
         .fetch_all(&self.pool)
         .await?;
@@ -1112,7 +1303,7 @@ impl UserAuthorizationService {
             r#"
             SELECT s.id, s.name, s.url, s.priority, s.media_streaming_mode, s.created_at, s.updated_at
             FROM servers s
-            JOIN server_mappings sm ON RTRIM(s.url, '/') = RTRIM(sm.server_url, '/')
+            JOIN server_mappings sm ON s.id = sm.server_id
             WHERE sm.user_id = ?
             ORDER BY s.priority DESC, s.name ASC
             "#,
@@ -1123,20 +1314,21 @@ impl UserAuthorizationService {
 
         let servers = rows
             .into_iter()
-            .map(|row| Server {
-                id: row.get("id"),
-                name: row.get("name"),
-                url: url::Url::parse(row.get::<String, _>("url").as_str())
-                    .unwrap_or_else(|_| url::Url::parse("http://invalid-url-in-db").unwrap()),
-                priority: row.get("priority"),
-                media_streaming_mode: row
-                    .get::<String, _>("media_streaming_mode")
-                    .parse()
-                    .unwrap_or(MediaStreamingMode::Redirect),
-                created_at: row.get("created_at"),
-                updated_at: row.get("updated_at"),
+            .map(|row| {
+                Ok(Server {
+                    id: ServerId::new(row.get("id")),
+                    name: row.get("name"),
+                    url: parse_server_url_column("url", row.get("url"))?,
+                    priority: row.get("priority"),
+                    media_streaming_mode: row
+                        .get::<String, _>("media_streaming_mode")
+                        .parse()
+                        .unwrap_or(MediaStreamingMode::Redirect),
+                    created_at: row.get("created_at"),
+                    updated_at: row.get("updated_at"),
+                })
             })
-            .collect();
+            .collect::<Result<Vec<_>, sqlx::Error>>()?;
 
         Ok(servers)
     }
@@ -1147,6 +1339,34 @@ mod tests {
     use crate::config::MIGRATOR;
 
     use super::*;
+
+    async fn setup_service() -> (SqlitePool, UserAuthorizationService) {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let service = UserAuthorizationService::new(pool.clone());
+        (pool, service)
+    }
+
+    async fn insert_test_server(pool: &SqlitePool, name: &str, url: &str) -> ServerId {
+        let now = chrono::Utc::now();
+        let id = sqlx::query_scalar::<_, i64>(
+            r#"
+            INSERT INTO servers (name, url, priority, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            RETURNING id
+            "#,
+        )
+        .bind(name)
+        .bind(url)
+        .bind(100)
+        .bind(now)
+        .bind(now)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+
+        ServerId::new(id)
+    }
 
     #[test]
     fn test_device_from_useragent_parsing() {
@@ -1227,6 +1447,103 @@ mod tests {
             all_users.len(),
             1,
             "should not create duplicate local users"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_store_authorization_session_upserts_existing_device_session() {
+        let (pool, service) = setup_service().await;
+        insert_test_server(&pool, "Test Server", "http://localhost:8096").await;
+
+        let user = service
+            .get_or_create_user("testuser", &"testpass".into())
+            .await
+            .unwrap();
+        let mapping_id = service
+            .add_server_mapping(
+                &user.id,
+                "http://localhost:8096",
+                "mappeduser",
+                &"mappedpass".into(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let mut auth = Authorization {
+            client: "Test Client".to_string(),
+            device: "Test Device".to_string(),
+            device_id: "test-device-id".to_string(),
+            version: "1.0.0".to_string(),
+            token: None,
+        };
+
+        let first_session_id = service
+            .store_authorization_session(
+                &user.id,
+                "http://localhost:8096",
+                &auth,
+                "old-token".to_string(),
+                "old-original-user".to_string(),
+                None,
+            )
+            .await
+            .unwrap();
+        let first_created_at = sqlx::query_scalar::<_, chrono::DateTime<chrono::Utc>>(
+            "SELECT created_at FROM authorization_sessions WHERE id = ?",
+        )
+        .bind(first_session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        auth.version = "2.0.0".to_string();
+
+        let second_session_id = service
+            .store_authorization_session(
+                &user.id,
+                "http://localhost:8096",
+                &auth,
+                "new-token".to_string(),
+                "new-original-user".to_string(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(first_session_id, second_session_id);
+
+        let count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM authorization_sessions WHERE mapping_id = ?",
+        )
+        .bind(mapping_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, 1);
+
+        let row = sqlx::query(
+            r#"
+            SELECT jellyfin_token, original_user_id, version, created_at
+            FROM authorization_sessions
+            WHERE id = ?
+            "#,
+        )
+        .bind(first_session_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(row.get::<String, _>("jellyfin_token"), "new-token");
+        assert_eq!(
+            row.get::<String, _>("original_user_id"),
+            "new-original-user"
+        );
+        assert_eq!(row.get::<String, _>("version"), "2.0.0");
+        assert_eq!(
+            row.get::<chrono::DateTime<chrono::Utc>, _>("created_at"),
+            first_created_at
         );
     }
 
@@ -2255,7 +2572,7 @@ mod tests {
             .1;
         assert_eq!(sessions_before.len(), 1);
 
-        // Delete mapping (should cascade delete session)
+        // Delete mapping (authorization sessions are removed explicitly before FK cascade backup)
         let deleted = service.delete_server_mapping(mapping_id).await.unwrap();
         assert!(deleted);
 
@@ -2269,7 +2586,7 @@ mod tests {
         assert_eq!(
             sessions_after.len(),
             0,
-            "Session should be deleted via cascade"
+            "Session should be deleted with the mapping"
         );
     }
 

--- a/crates/jellyswarrm-proxy/src/user_authorization_service.rs
+++ b/crates/jellyswarrm-proxy/src/user_authorization_service.rs
@@ -572,7 +572,7 @@ impl UserAuthorizationService {
         )
         .bind(user_id)
         .bind(server_id.as_i64())
-        .bind(&server_url)
+        .bind(server_url)
         .bind(mapped_username)
         .bind(final_password)
         .bind(now)
@@ -749,6 +749,7 @@ impl UserAuthorizationService {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn store_authorization_session_by_id(
         &self,
         user_id: &str,
@@ -786,7 +787,7 @@ impl UserAuthorizationService {
         )
         .bind(user_id)
         .bind(mapping.id)
-        .bind(&server_url)
+        .bind(server_url)
         .bind(&authorization.client)
         .bind(&authorization.device)
         .bind(&authorization.device_id)

--- a/crates/jellyswarrm-proxy/src/user_authorization_service.rs
+++ b/crates/jellyswarrm-proxy/src/user_authorization_service.rs
@@ -276,6 +276,31 @@ impl UserAuthorizationService {
         username.trim().to_string()
     }
 
+    fn mapping_credentials_changed(
+        existing_mapping: &ServerMapping,
+        mapped_username: &str,
+        mapped_password: &Password,
+        master_password: Option<&HashedPassword>,
+    ) -> bool {
+        if !existing_mapping
+            .mapped_username
+            .trim()
+            .eq_ignore_ascii_case(mapped_username.trim())
+        {
+            return true;
+        }
+
+        if let Some(master_password) = master_password {
+            if let Ok(existing_password) =
+                decrypt_password(&existing_mapping.mapped_password, master_password)
+            {
+                return existing_password != *mapped_password;
+            }
+        }
+
+        existing_mapping.mapped_password.as_str() != mapped_password.as_str()
+    }
+
     #[cfg(test)]
     async fn resolve_server_reference(
         &self,
@@ -543,6 +568,14 @@ impl UserAuthorizationService {
         let existing_mapping = self
             .get_server_mapping_by_server_id(user_id, server_id)
             .await?;
+        let credentials_changed = existing_mapping.as_ref().is_some_and(|existing_mapping| {
+            Self::mapping_credentials_changed(
+                existing_mapping,
+                mapped_username,
+                mapped_password,
+                master_password,
+            )
+        });
 
         let final_password = if let Some(master) = master_password {
             match encrypt_password(mapped_password, master) {
@@ -556,6 +589,8 @@ impl UserAuthorizationService {
             warn!("No encryption password provided. Storing as plaintext!");
             EncryptedPassword::from_raw(mapped_password.as_str().into())
         };
+
+        let mut tx = self.pool.begin().await?;
 
         let mapping_id = sqlx::query_scalar::<_, i64>(
             r#"
@@ -577,24 +612,23 @@ impl UserAuthorizationService {
         .bind(final_password)
         .bind(now)
         .bind(now)
-        .fetch_one(&self.pool)
+        .fetch_one(&mut *tx)
         .await?;
 
-        if let Some(existing_mapping) = existing_mapping {
-            if !existing_mapping
-                .mapped_username
-                .trim()
-                .eq_ignore_ascii_case(mapped_username.trim())
-            {
-                info!(
-                    "Mapped username changed for user {} on server {} from '{}' to '{}'. Sessions were preserved; callers must revoke affected mapping sessions explicitly if needed.",
-                    user_id,
-                    server_url,
-                    existing_mapping.mapped_username,
-                    mapped_username
-                );
-            }
+        if credentials_changed {
+            let deleted = sqlx::query("DELETE FROM authorization_sessions WHERE mapping_id = ?")
+                .bind(mapping_id)
+                .execute(&mut *tx)
+                .await?
+                .rows_affected();
+
+            info!(
+                "Mapped credentials changed for user {} on server {}. Deleted {} affected session(s).",
+                user_id, server_url, deleted
+            );
         }
+
+        tx.commit().await?;
 
         info!(
             "Added or updated server mapping for user {} to server {}",
@@ -2774,14 +2808,14 @@ mod tests {
             .await
             .unwrap();
 
-        // Re-add mapping for same user/server with same mapped account.
+        // Re-add mapping for same user/server with identical credentials.
         // Should update in place and preserve sessions.
         let mapping_id_2 = service
             .add_server_mapping(
                 &user.id,
                 "http://localhost:8096",
                 "mappeduser",
-                &"mappedpass-updated".into(),
+                &"mappedpass".into(),
                 None,
             )
             .await
@@ -2837,7 +2871,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_add_server_mapping_username_change_preserves_sessions_until_explicit_revoke() {
+    async fn test_add_server_mapping_username_change_deletes_sessions() {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
         MIGRATOR.run(&pool).await.unwrap();
         let service = UserAuthorizationService::new(pool.clone());
@@ -2917,9 +2951,8 @@ mod tests {
             .1;
         assert_eq!(sessions_before.len(), 1);
 
-        // Change mapped username -> sessions stay until the caller explicitly revokes the
-        // affected mapping.
-        let mapping_id = service
+        // Change mapped username -> affected sessions are revoked by the service.
+        service
             .add_server_mapping(
                 &user.id,
                 "http://localhost:8096",
@@ -2937,20 +2970,67 @@ mod tests {
             .unwrap()
             .1;
 
-        assert_eq!(sessions_after.len(), 1);
+        assert_eq!(sessions_after.len(), 0);
+    }
 
-        let deleted = service
-            .delete_sessions_for_mapping(mapping_id)
+    #[tokio::test]
+    async fn test_add_server_mapping_password_change_deletes_sessions() {
+        let (pool, service) = setup_service().await;
+        insert_test_server(&pool, "Server 1", "http://localhost:8096").await;
+
+        let user = service
+            .get_or_create_user("testuser", &"testpass".into())
             .await
             .unwrap();
-        assert_eq!(deleted, 1);
 
-        let sessions_after_revoke = service
+        service
+            .add_server_mapping(
+                &user.id,
+                "http://localhost:8096",
+                "mappeduser",
+                &"mappedpass-a".into(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let auth = Authorization {
+            client: "Jellyfin Web".to_string(),
+            device: "Firefox".to_string(),
+            device_id: "device-1".to_string(),
+            version: "10.0.0".to_string(),
+            token: None,
+        };
+
+        service
+            .store_authorization_session(
+                &user.id,
+                "http://localhost:8096",
+                &auth,
+                "token-1".to_string(),
+                "orig-user-1".to_string(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        service
+            .add_server_mapping(
+                &user.id,
+                "http://localhost:8096",
+                "mappeduser",
+                &"mappedpass-b".into(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let sessions_after = service
             .get_user_sessions_by_virtual_token(&user.virtual_key)
             .await
             .unwrap()
             .unwrap()
             .1;
-        assert_eq!(sessions_after_revoke.len(), 0);
+        assert_eq!(sessions_after.len(), 0);
     }
 }


### PR DESCRIPTION
Introduces a `ServerId` type that represents a unique server. Remove all server fetching via url. 

Constrain Sessions to `ServerIds` and prune them. 

Should fix duplicated session problems as described in:  #121 #111 