### PR TITLE
Grouped Library Policy when not auto merged

### DIFF
--- a/crates/jellyswarrm-proxy/migrations/20260608120000_add_library_groups.down.sql
+++ b/crates/jellyswarrm-proxy/migrations/20260608120000_add_library_groups.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_library_group_members_server_library;
+DROP TABLE IF EXISTS library_group_members;
+DROP TABLE IF EXISTS library_groups;

--- a/crates/jellyswarrm-proxy/migrations/20260608120000_add_library_groups.up.sql
+++ b/crates/jellyswarrm-proxy/migrations/20260608120000_add_library_groups.up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS library_groups (
+    virtual_id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL UNIQUE,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS library_group_members (
+    group_virtual_id TEXT NOT NULL REFERENCES library_groups(virtual_id) ON DELETE CASCADE,
+    server_id INTEGER NOT NULL,
+    original_library_id TEXT NOT NULL,
+    library_name TEXT NOT NULL,
+    PRIMARY KEY (group_virtual_id, server_id, original_library_id),
+    FOREIGN KEY (server_id) REFERENCES servers(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_library_group_members_server_library
+    ON library_group_members (server_id, original_library_id);

--- a/crates/jellyswarrm-proxy/migrations/20260608130000_add_library_duplicate_policy.down.sql
+++ b/crates/jellyswarrm-proxy/migrations/20260608130000_add_library_duplicate_policy.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE library_groups DROP COLUMN preferred_server_id;
+ALTER TABLE library_groups DROP COLUMN duplicate_policy;

--- a/crates/jellyswarrm-proxy/migrations/20260608130000_add_library_duplicate_policy.up.sql
+++ b/crates/jellyswarrm-proxy/migrations/20260608130000_add_library_duplicate_policy.up.sql
@@ -1,0 +1,14 @@
+ALTER TABLE library_groups
+ADD COLUMN duplicate_policy TEXT NOT NULL DEFAULT 'ShowAll'
+CHECK (duplicate_policy IN (
+    'ShowAll',
+    'LargestSize',
+    'SmallestSize',
+    'BestQuality',
+    'LowestQuality',
+    'PreferServer',
+    'ServerPriority'
+));
+
+ALTER TABLE library_groups
+ADD COLUMN preferred_server_id INTEGER REFERENCES servers(id) ON DELETE SET NULL;

--- a/crates/jellyswarrm-proxy/migrations/20260610120000_library_group_duplicate_policy_default.down.sql
+++ b/crates/jellyswarrm-proxy/migrations/20260610120000_library_group_duplicate_policy_default.down.sql
@@ -1,0 +1,3 @@
+UPDATE library_groups
+SET duplicate_policy = 'ShowAll'
+WHERE duplicate_policy = 'ServerPriority';

--- a/crates/jellyswarrm-proxy/migrations/20260610120000_library_group_duplicate_policy_default.up.sql
+++ b/crates/jellyswarrm-proxy/migrations/20260610120000_library_group_duplicate_policy_default.up.sql
@@ -1,0 +1,3 @@
+UPDATE library_groups
+SET duplicate_policy = 'ServerPriority'
+WHERE duplicate_policy = 'ShowAll';

--- a/crates/jellyswarrm-proxy/src/duplicate_policy.rs
+++ b/crates/jellyswarrm-proxy/src/duplicate_policy.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    models::MediaItem,
+    models::{enums::BaseItemKind, MediaItem},
     server_id::ServerId,
     server_storage::Server,
 };
@@ -76,10 +76,6 @@ pub fn deduplicate_tagged_items(
     items: Vec<TaggedMediaItem>,
     config: &DuplicatePolicyConfig,
 ) -> Vec<MediaItem> {
-    if config.policy == DuplicatePolicy::ShowAll {
-        return items.into_iter().map(|tagged| tagged.item).collect();
-    }
-
     let mut groups: HashMap<String, Vec<TaggedMediaItem>> = HashMap::new();
     for tagged in items {
         groups
@@ -89,26 +85,47 @@ pub fn deduplicate_tagged_items(
     }
 
     let mut winners = Vec::with_capacity(groups.len());
-    for (_, mut group) in groups {
-        if group.len() == 1 {
-            winners.push(group.remove(0).item);
-            continue;
-        }
-
-        let winner = group
-            .into_iter()
-            .max_by(|left, right| {
-                compare_for_policy(config, left, right)
-                    .then_with(|| left.item.id.cmp(&right.item.id))
-            })
-            .map(|tagged| tagged.item);
-
-        if let Some(item) = winner {
-            winners.push(item);
-        }
+    for (_, group) in groups {
+        winners.extend(select_from_duplicate_group(group, config));
     }
 
     winners
+}
+
+fn select_from_duplicate_group(
+    group: Vec<TaggedMediaItem>,
+    config: &DuplicatePolicyConfig,
+) -> Vec<MediaItem> {
+    if group.len() == 1 {
+        return vec![group[0].item.clone()];
+    }
+
+    let max_score = group
+        .iter()
+        .map(|tagged| duplicate_preference_score(&tagged.item))
+        .max()
+        .unwrap_or(0);
+    let mut best_matches = group
+        .into_iter()
+        .filter(|tagged| duplicate_preference_score(&tagged.item) == max_score)
+        .collect::<Vec<_>>();
+
+    if best_matches.len() == 1 {
+        return vec![best_matches.remove(0).item];
+    }
+
+    if config.policy == DuplicatePolicy::ShowAll {
+        return best_matches.into_iter().map(|tagged| tagged.item).collect();
+    }
+
+    best_matches
+        .into_iter()
+        .max_by(|left, right| {
+            compare_for_policy(config, left, right)
+                .then_with(|| left.item.id.cmp(&right.item.id))
+        })
+        .map(|tagged| vec![tagged.item])
+        .unwrap_or_default()
 }
 
 fn compare_for_policy(
@@ -162,22 +179,90 @@ fn prefer_server(
 }
 
 fn duplicate_key(item: &MediaItem) -> String {
-    if let Some(provider_key) = provider_identity(item) {
-        return format!("provider:{provider_key}:{:?}", item.item_type);
+    if item.item_type == BaseItemKind::Episode {
+        return episode_duplicate_key(item);
     }
 
     let name = normalized_name(item);
-    let year = production_year(item).unwrap_or(0);
-    let series = item.series_id.as_deref().unwrap_or("");
-    format!("fallback:{name}:{year}:{series}:{:?}", item.item_type)
+    format!("content:{name}:{:?}", item.item_type)
+}
+
+fn episode_duplicate_key(item: &MediaItem) -> String {
+    if let Some(user_key) = item.user_data.as_ref().and_then(|data| {
+        let key = data.key.trim();
+        if key.is_empty() || key.chars().all(|character| character == '0') {
+            None
+        } else {
+            Some(key.to_string())
+        }
+    }) {
+        return format!("episode:userkey:{user_key}");
+    }
+
+    if let Some(provider_key) = provider_identity(item) {
+        let season = episode_number(item, "ParentIndexNumber");
+        let episode = episode_number(item, "IndexNumber");
+        return format!("episode:provider:{provider_key}:s{season}:e{episode}");
+    }
+
+    let series = item
+        .series_name
+        .as_deref()
+        .map(normalize_title)
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| normalized_name(item));
+    let season = episode_number(item, "ParentIndexNumber");
+    let episode = episode_number(item, "IndexNumber");
+    format!("episode:fallback:{series}:s{season}:e{episode}")
+}
+
+fn episode_number(item: &MediaItem, field: &str) -> i32 {
+    item.extra
+        .get(field)
+        .or_else(|| {
+            item.extra.get(match field {
+                "ParentIndexNumber" => "parentIndexNumber",
+                _ => "indexNumber",
+            })
+        })
+        .and_then(|value| value.as_i64())
+        .unwrap_or(0) as i32
+}
+
+fn duplicate_preference_score(item: &MediaItem) -> i64 {
+    if item.item_type == BaseItemKind::Episode {
+        if let Some(user_data) = &item.user_data {
+            if user_data.playback_position_ticks > 0 {
+                return user_data.playback_position_ticks;
+            }
+            if user_data.play_count > 0 {
+                return i64::from(user_data.play_count);
+            }
+        }
+        return 0;
+    }
+
+    item.child_count
+        .map(|count| i64::from(count.max(0)))
+        .or_else(|| {
+            item.extra
+                .get("ChildCount")
+                .or_else(|| item.extra.get("childCount"))
+                .and_then(|value| value.as_i64())
+        })
+        .unwrap_or(0)
 }
 
 fn provider_identity(item: &MediaItem) -> Option<String> {
     let provider_ids = item.provider_ids.as_ref()?.as_object()?;
-    for key in ["Tmdb", "Imdb", "Tvdb", "TmdbCollection"] {
-        if let Some(value) = provider_ids.get(key).and_then(|value| value.as_str()) {
-            if !value.is_empty() {
-                return Some(format!("{key}:{value}"));
+    for preferred in ["Tmdb", "Imdb", "Tvdb", "TmdbCollection"] {
+        for (key, value) in provider_ids {
+            if key.eq_ignore_ascii_case(preferred) {
+                if let Some(id) = value.as_str() {
+                    if !id.is_empty() {
+                        return Some(format!("{}:{id}", preferred.to_ascii_lowercase()));
+                    }
+                }
             }
         }
     }
@@ -185,20 +270,37 @@ fn provider_identity(item: &MediaItem) -> Option<String> {
 }
 
 fn normalized_name(item: &MediaItem) -> String {
-    item.sort_name
+    let raw = item
+        .sort_name
         .as_deref()
+        .or(item.original_title.as_deref())
         .or(item.name.as_deref())
-        .unwrap_or("")
-        .trim()
-        .to_ascii_lowercase()
+        .unwrap_or("");
+    normalize_title(raw)
 }
 
-fn production_year(item: &MediaItem) -> Option<i32> {
-    item.extra
-        .get("ProductionYear")
-        .or_else(|| item.extra.get("productionYear"))
-        .and_then(|value| value.as_i64())
-        .map(|value| value as i32)
+fn normalize_title(value: &str) -> String {
+    let value = value.trim();
+    let value = value
+        .rsplit_once('[')
+        .filter(|(_, suffix)| suffix.ends_with(']'))
+        .map(|(prefix, _)| prefix.trim_end())
+        .unwrap_or(value);
+
+    value
+        .to_ascii_lowercase()
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character
+            } else {
+                ' '
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn media_size(item: &MediaItem) -> i64 {
@@ -306,19 +408,42 @@ mod tests {
     }
 
     #[test]
-    fn prefers_selected_server() {
-        let items = vec![
-            tagged(1, 100, "Movie", 5000, "abc"),
-            tagged(2, 50, "Movie", 1000, "abc"),
-        ];
+    fn prefers_more_complete_series() {
+        let mut less: MediaItem = serde_json::from_value(serde_json::json!({
+            "Id": "left",
+            "Name": "Wistoria",
+            "Type": "Series",
+            "ChildCount": 12,
+            "ProviderIds": { "Tmdb": "abc" }
+        }))
+        .unwrap();
+        let more: MediaItem = serde_json::from_value(serde_json::json!({
+            "Id": "right",
+            "Name": "Wistoria",
+            "Type": "Series",
+            "ChildCount": 21,
+            "ProviderIds": { "Tmdb": "abc" }
+        }))
+        .unwrap();
+        let _ = &mut less;
+
         let result = deduplicate_tagged_items(
-            items,
+            vec![
+                TaggedMediaItem {
+                    item: less,
+                    server: tagged(1, 100, "x", 1, "abc").server,
+                },
+                TaggedMediaItem {
+                    item: more,
+                    server: tagged(2, 50, "x", 1, "abc").server,
+                },
+            ],
             &DuplicatePolicyConfig {
-                policy: DuplicatePolicy::PreferServer,
-                preferred_server_id: Some(ServerId::new(2)),
+                policy: DuplicatePolicy::ShowAll,
+                preferred_server_id: None,
             },
         );
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].id, "2-Movie");
+        assert_eq!(result[0].id, "right");
     }
 }

--- a/crates/jellyswarrm-proxy/src/duplicate_policy.rs
+++ b/crates/jellyswarrm-proxy/src/duplicate_policy.rs
@@ -1,0 +1,324 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    models::MediaItem,
+    server_id::ServerId,
+    server_storage::Server,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub enum DuplicatePolicy {
+    #[default]
+    ShowAll,
+    LargestSize,
+    SmallestSize,
+    BestQuality,
+    LowestQuality,
+    PreferServer,
+    ServerPriority,
+}
+
+impl DuplicatePolicy {
+    pub fn label(self) -> &'static str {
+        match self {
+            DuplicatePolicy::ShowAll => "Show all duplicates",
+            DuplicatePolicy::LargestSize => "Keep largest file",
+            DuplicatePolicy::SmallestSize => "Keep smallest file",
+            DuplicatePolicy::BestQuality => "Keep best quality",
+            DuplicatePolicy::LowestQuality => "Keep lowest quality",
+            DuplicatePolicy::PreferServer => "Prefer selected server",
+            DuplicatePolicy::ServerPriority => "Prefer highest server priority",
+        }
+    }
+}
+
+impl FromStr for DuplicatePolicy {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "ShowAll" => Ok(DuplicatePolicy::ShowAll),
+            "LargestSize" => Ok(DuplicatePolicy::LargestSize),
+            "SmallestSize" => Ok(DuplicatePolicy::SmallestSize),
+            "BestQuality" => Ok(DuplicatePolicy::BestQuality),
+            "LowestQuality" => Ok(DuplicatePolicy::LowestQuality),
+            "PreferServer" => Ok(DuplicatePolicy::PreferServer),
+            "ServerPriority" => Ok(DuplicatePolicy::ServerPriority),
+            _ => Err(format!("Invalid duplicate policy: {value}")),
+        }
+    }
+}
+
+impl fmt::Display for DuplicatePolicy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DuplicatePolicyConfig {
+    pub policy: DuplicatePolicy,
+    pub preferred_server_id: Option<ServerId>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TaggedMediaItem {
+    pub item: MediaItem,
+    pub server: Server,
+}
+
+pub fn deduplicate_tagged_items(
+    items: Vec<TaggedMediaItem>,
+    config: &DuplicatePolicyConfig,
+) -> Vec<MediaItem> {
+    if config.policy == DuplicatePolicy::ShowAll {
+        return items.into_iter().map(|tagged| tagged.item).collect();
+    }
+
+    let mut groups: HashMap<String, Vec<TaggedMediaItem>> = HashMap::new();
+    for tagged in items {
+        groups
+            .entry(duplicate_key(&tagged.item))
+            .or_default()
+            .push(tagged);
+    }
+
+    let mut winners = Vec::with_capacity(groups.len());
+    for (_, mut group) in groups {
+        if group.len() == 1 {
+            winners.push(group.remove(0).item);
+            continue;
+        }
+
+        let winner = group
+            .into_iter()
+            .max_by(|left, right| {
+                compare_for_policy(config, left, right)
+                    .then_with(|| left.item.id.cmp(&right.item.id))
+            })
+            .map(|tagged| tagged.item);
+
+        if let Some(item) = winner {
+            winners.push(item);
+        }
+    }
+
+    winners
+}
+
+fn compare_for_policy(
+    config: &DuplicatePolicyConfig,
+    left: &TaggedMediaItem,
+    right: &TaggedMediaItem,
+) -> std::cmp::Ordering {
+    match config.policy {
+        DuplicatePolicy::ShowAll => std::cmp::Ordering::Equal,
+        DuplicatePolicy::LargestSize => media_size(&left.item).cmp(&media_size(&right.item)),
+        DuplicatePolicy::SmallestSize => media_size(&right.item).cmp(&media_size(&left.item)),
+        DuplicatePolicy::BestQuality => quality_score(&left.item).cmp(&quality_score(&right.item)),
+        DuplicatePolicy::LowestQuality => {
+            quality_score(&right.item).cmp(&quality_score(&left.item))
+        }
+        DuplicatePolicy::PreferServer => {
+            prefer_server(left, right, config.preferred_server_id)
+        }
+        DuplicatePolicy::ServerPriority => left
+            .server
+            .priority
+            .cmp(&right.server.priority)
+            .then_with(|| left.server.id.as_i64().cmp(&right.server.id.as_i64())),
+    }
+}
+
+fn prefer_server(
+    left: &TaggedMediaItem,
+    right: &TaggedMediaItem,
+    preferred_server_id: Option<ServerId>,
+) -> std::cmp::Ordering {
+    let Some(preferred) = preferred_server_id else {
+        return left
+            .server
+            .priority
+            .cmp(&right.server.priority)
+            .then_with(|| left.server.id.as_i64().cmp(&right.server.id.as_i64()));
+    };
+
+    let left_matches = left.server.id == preferred;
+    let right_matches = right.server.id == preferred;
+    match (left_matches, right_matches) {
+        (true, false) => std::cmp::Ordering::Greater,
+        (false, true) => std::cmp::Ordering::Less,
+        _ => left
+            .server
+            .priority
+            .cmp(&right.server.priority)
+            .then_with(|| media_size(&left.item).cmp(&media_size(&right.item))),
+    }
+}
+
+fn duplicate_key(item: &MediaItem) -> String {
+    if let Some(provider_key) = provider_identity(item) {
+        return format!("provider:{provider_key}:{:?}", item.item_type);
+    }
+
+    let name = normalized_name(item);
+    let year = production_year(item).unwrap_or(0);
+    let series = item.series_id.as_deref().unwrap_or("");
+    format!("fallback:{name}:{year}:{series}:{:?}", item.item_type)
+}
+
+fn provider_identity(item: &MediaItem) -> Option<String> {
+    let provider_ids = item.provider_ids.as_ref()?.as_object()?;
+    for key in ["Tmdb", "Imdb", "Tvdb", "TmdbCollection"] {
+        if let Some(value) = provider_ids.get(key).and_then(|value| value.as_str()) {
+            if !value.is_empty() {
+                return Some(format!("{key}:{value}"));
+            }
+        }
+    }
+    None
+}
+
+fn normalized_name(item: &MediaItem) -> String {
+    item.sort_name
+        .as_deref()
+        .or(item.name.as_deref())
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase()
+}
+
+fn production_year(item: &MediaItem) -> Option<i32> {
+    item.extra
+        .get("ProductionYear")
+        .or_else(|| item.extra.get("productionYear"))
+        .and_then(|value| value.as_i64())
+        .map(|value| value as i32)
+}
+
+fn media_size(item: &MediaItem) -> i64 {
+    if let Some(sources) = &item.media_sources {
+        return sources.iter().filter_map(|source| source.size).sum();
+    }
+
+    item.extra
+        .get("Size")
+        .or_else(|| item.extra.get("size"))
+        .and_then(|value| value.as_i64())
+        .unwrap_or(0)
+}
+
+fn quality_score(item: &MediaItem) -> i64 {
+    let mut best = 0i64;
+
+    if let Some(sources) = &item.media_sources {
+        for source in sources {
+            if let Some(bitrate) = source.bitrate {
+                best = best.max(bitrate);
+            }
+            if let Some(streams) = &source.media_streams {
+                for stream in streams {
+                    if stream.stream_type.as_deref() == Some("Video") {
+                        if let Some(height) = stream.height {
+                            best = best.max(i64::from(height) * 1_000_000);
+                        }
+                        if let Some(bit_rate) = stream.bit_rate {
+                            best = best.max(bit_rate);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if best > 0 {
+        return best;
+    }
+
+    if let Some(streams) = &item.media_streams {
+        for stream in streams {
+            if stream.stream_type.as_deref() == Some("Video") {
+                if let Some(height) = stream.height {
+                    best = best.max(i64::from(height) * 1_000_000);
+                }
+                if let Some(bit_rate) = stream.bit_rate {
+                    best = best.max(bit_rate);
+                }
+            }
+        }
+    }
+
+    best.max(media_size(item))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        config::MediaStreamingMode,
+        server_url::ServerUrl,
+    };
+
+    fn tagged(server_id: i64, priority: i32, name: &str, size: i64, provider: &str) -> TaggedMediaItem {
+        let item: MediaItem = serde_json::from_value(serde_json::json!({
+            "Id": format!("{server_id}-{name}"),
+            "Name": name,
+            "Type": "Movie",
+            "ProviderIds": { "Tmdb": provider },
+            "MediaSources": [{ "Id": "1", "Size": size }]
+        }))
+        .unwrap();
+
+        TaggedMediaItem {
+            item,
+            server: Server {
+                id: ServerId::new(server_id),
+                name: format!("Server {server_id}"),
+                url: ServerUrl::parse("http://example:8096").unwrap(),
+                priority,
+                media_streaming_mode: MediaStreamingMode::Redirect,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            },
+        }
+    }
+
+    #[test]
+    fn keeps_largest_duplicate() {
+        let items = vec![
+            tagged(1, 100, "Movie", 1000, "abc"),
+            tagged(2, 100, "Movie", 5000, "abc"),
+        ];
+        let result = deduplicate_tagged_items(
+            items,
+            &DuplicatePolicyConfig {
+                policy: DuplicatePolicy::LargestSize,
+                preferred_server_id: None,
+            },
+        );
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, "2-Movie");
+    }
+
+    #[test]
+    fn prefers_selected_server() {
+        let items = vec![
+            tagged(1, 100, "Movie", 5000, "abc"),
+            tagged(2, 50, "Movie", 1000, "abc"),
+        ];
+        let result = deduplicate_tagged_items(
+            items,
+            &DuplicatePolicyConfig {
+                policy: DuplicatePolicy::PreferServer,
+                preferred_server_id: Some(ServerId::new(2)),
+            },
+        );
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, "2-Movie");
+    }
+}

--- a/crates/jellyswarrm-proxy/src/handlers/common.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/common.rs
@@ -434,6 +434,7 @@ mod tests {
         config::{AppConfig, MediaStreamingMode, MIGRATOR},
         media_storage_service::MediaStorageService,
         merged_library_service::MergedLibraryService,
+        library_group_service::LibraryGroupService,
         server_id::ServerId,
         server_storage::ServerStorageService,
         server_url::ServerUrl,
@@ -481,7 +482,8 @@ mod tests {
             user_authorization: Arc::new(UserAuthorizationService::new(pool.clone())),
             server_storage: Arc::new(ServerStorageService::new(pool.clone())),
             media_storage: Arc::new(MediaStorageService::new(pool.clone())),
-            merged_library_service: Arc::new(MergedLibraryService::new(pool)),
+            merged_library_service: Arc::new(MergedLibraryService::new(pool.clone())),
+            library_group_service: Arc::new(LibraryGroupService::new(pool)),
             play_sessions: Arc::new(SessionStorage::new()),
             config: Arc::new(tokio::sync::RwLock::new(config)),
         };

--- a/crates/jellyswarrm-proxy/src/handlers/federated.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/federated.rs
@@ -223,24 +223,42 @@ async fn get_items_for_merged_library(
         ensure_dedup_fields(request.url_mut());
 
         let state_clone = state.clone();
+        let use_limited_upstream =
+            is_upstream_limited_catalog_request(original_request.url());
+        let max_pages = merged_library_max_pages(pagination);
         join_set.spawn(async move {
-            let result = fetch_all_items_from_server(
-                index,
-                state_clone,
-                request,
-                session,
-                server,
-                false,
-            )
-            .await;
+            let result = if use_limited_upstream {
+                fetch_items_from_server(
+                    index,
+                    state_clone,
+                    request,
+                    session,
+                    server,
+                    pagination,
+                    false,
+                )
+                .await
+                .map(|items| merged_server_fetch_from_response(items, true))
+            } else {
+                fetch_windowed_items_from_server(
+                    index,
+                    state_clone,
+                    request,
+                    session,
+                    server,
+                    max_pages,
+                    false,
+                )
+                .await
+            };
             (index, result)
         });
     }
 
-    let mut indexed_results: Vec<(usize, ItemsResponseVariants)> = Vec::new();
+    let mut indexed_results: Vec<(usize, MergedServerFetch)> = Vec::new();
     while let Some(result) = join_set.join_next().await {
         match result {
-            Ok((index, Ok(items))) => indexed_results.push((index, items)),
+            Ok((index, Ok(fetch))) => indexed_results.push((index, fetch)),
             Ok((_, Err(e))) => {
                 failures += 1;
                 error!("Merged library fan-out failed: {:?}", e);
@@ -267,15 +285,25 @@ async fn get_items_for_merged_library(
     indexed_results.sort_by_key(|(index, _)| *index);
     let wrapped_response = indexed_results
         .iter()
-        .any(|(_, items)| matches!(items, ItemsResponseVariants::WithCount(_)));
-    let all_items: Vec<TaggedMediaItem> = indexed_results
+        .any(|(_, fetch)| matches!(fetch.items, ItemsResponseVariants::WithCount(_)));
+    let mut raw_count = 0usize;
+    let mut upstream_total_sum = 0i32;
+    let mut all_fully_fetched = true;
+    let tagged_items: Vec<TaggedMediaItem> = indexed_results
         .into_iter()
-        .flat_map(|(index, response)| {
+        .flat_map(|(index, fetch)| {
+            raw_count += fetch.raw_count;
+            if let Some(total) = fetch.upstream_total {
+                upstream_total_sum += total.max(0);
+            }
+            all_fully_fetched &= fetch.fully_fetched;
+
             let Some(server) = member_servers.get(&index).cloned() else {
                 error!("Missing server mapping for merged fan-out index {}", index);
                 return Vec::new();
             };
-            response
+            fetch
+                .items
                 .into_items()
                 .into_iter()
                 .map(move |item| TaggedMediaItem { item, server: server.clone() })
@@ -283,14 +311,20 @@ async fn get_items_for_merged_library(
         })
         .collect();
 
-    let mut all_items = deduplicate_tagged_items(all_items, &duplicate_config);
+    let mut all_items = deduplicate_tagged_items(tagged_items, &duplicate_config);
     all_items.sort_by(|a, b| {
         let left = a.sort_name.as_deref().or(a.name.as_deref()).unwrap_or("");
         let right = b.sort_name.as_deref().or(b.name.as_deref()).unwrap_or("");
         left.cmp(right)
     });
 
-    let (paged_items, total_count) = apply_pagination(all_items, pagination);
+    let total_count = estimate_merged_library_total(
+        all_items.len(),
+        raw_count,
+        upstream_total_sum,
+        all_fully_fetched,
+    );
+    let (paged_items, _) = apply_pagination(all_items, pagination);
     items_response_to_json(items_response_from_shape(
         paged_items,
         total_count,
@@ -916,19 +950,162 @@ async fn fetch_items_from_server(
 
 const UPSTREAM_PAGE_SIZE: usize = 100;
 const MAX_PARALLEL_UPSTREAM_PAGES: usize = 8;
+const MAX_MERGED_LIBRARY_PAGES: usize = 12;
 
-async fn fetch_all_items_from_server(
+struct MergedServerFetch {
+    items: ItemsResponseVariants,
+    upstream_total: Option<i32>,
+    fully_fetched: bool,
+    raw_count: usize,
+}
+
+fn is_upstream_limited_catalog_request(url: &url::Url) -> bool {
+    let path = url.path().to_ascii_lowercase();
+    path.contains("/latest") || path.contains("/suggestions")
+}
+
+fn merged_library_max_pages(pagination: Pagination) -> usize {
+    let Some(client_limit) = pagination.limit else {
+        return MAX_MERGED_LIBRARY_PAGES;
+    };
+    let window_end = pagination.start_index.saturating_add(client_limit);
+    let buffered = window_end.saturating_mul(3).div_ceil(2);
+    let pages = buffered.div_ceil(UPSTREAM_PAGE_SIZE).max(1);
+    pages.min(MAX_MERGED_LIBRARY_PAGES)
+}
+
+fn merged_server_fetch_from_response(
+    items: ItemsResponseVariants,
+    fully_fetched: bool,
+) -> MergedServerFetch {
+    let upstream_total = match &items {
+        ItemsResponseVariants::WithCount(response) => Some(response.total_record_count),
+        ItemsResponseVariants::Bare(_) => None,
+    };
+    let raw_count = items.len();
+    MergedServerFetch {
+        items,
+        upstream_total,
+        fully_fetched,
+        raw_count,
+    }
+}
+
+fn estimate_merged_library_total(
+    deduped_len: usize,
+    raw_count: usize,
+    upstream_total_sum: i32,
+    all_fully_fetched: bool,
+) -> usize {
+    if all_fully_fetched {
+        return deduped_len;
+    }
+
+    if raw_count > 0 && upstream_total_sum > 0 {
+        let ratio = deduped_len as f64 / raw_count as f64;
+        let estimated = (f64::from(upstream_total_sum) * ratio).round() as usize;
+        return estimated.max(deduped_len);
+    }
+
+    deduped_len.max(upstream_total_sum.max(0) as usize)
+}
+
+async fn fetch_windowed_items_from_server(
     index: usize,
     state: AppState,
     request: reqwest::Request,
     session: AuthorizationSession,
     server: Server,
+    max_pages: usize,
     should_change_name: bool,
-) -> Result<ItemsResponseVariants, StatusCode> {
-    let (mut items_response, server) =
-        fetch_all_raw_items_from_server(index, state.clone(), request, session, server).await?;
+) -> Result<MergedServerFetch, StatusCode> {
+    let (mut items_response, upstream_total, fully_fetched) = fetch_windowed_raw_items_from_server(
+        index,
+        state.clone(),
+        request,
+        session,
+        server.clone(),
+        max_pages,
+    )
+    .await?;
+    let raw_count = items_response.len();
     process_items_response_json(&mut items_response, &state, &server, should_change_name).await?;
-    Ok(items_response)
+    Ok(MergedServerFetch {
+        items: items_response,
+        upstream_total,
+        fully_fetched,
+        raw_count,
+    })
+}
+
+async fn fetch_windowed_raw_items_from_server(
+    index: usize,
+    state: AppState,
+    request: reqwest::Request,
+    session: AuthorizationSession,
+    server: Server,
+    max_pages: usize,
+) -> Result<(ItemsResponseVariants, Option<i32>, bool), StatusCode> {
+    let first_page = fetch_upstream_page_raw(
+        index,
+        state.clone(),
+        request
+            .try_clone()
+            .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?,
+        session.clone(),
+        server.clone(),
+        0,
+    )
+    .await?;
+
+    let had_counted_response = matches!(&first_page, ItemsResponseVariants::WithCount(_));
+    let upstream_total = match &first_page {
+        ItemsResponseVariants::WithCount(response) => Some(response.total_record_count),
+        ItemsResponseVariants::Bare(_) => None,
+    };
+    let first_page_len = first_page.len();
+    let mut all_items = first_page.into_items();
+
+    let mut fully_fetched = first_page_len < UPSTREAM_PAGE_SIZE;
+    if max_pages > 1 && should_continue_upstream_fetch(first_page_len, UPSTREAM_PAGE_SIZE) {
+        let page_starts: Vec<usize> = (1..max_pages)
+            .map(|page| page * UPSTREAM_PAGE_SIZE)
+            .collect();
+        let extra_pages = fetch_upstream_pages_parallel(
+            index,
+            state.clone(),
+            &request,
+            session.clone(),
+            server.clone(),
+            &page_starts,
+        )
+        .await?;
+
+        if let Some((_, last_page)) = extra_pages.last() {
+            fully_fetched = last_page.len() < UPSTREAM_PAGE_SIZE;
+        }
+        for (_, page) in extra_pages {
+            all_items.extend(page.into_items());
+        }
+    }
+
+    if let Some(total) = upstream_total {
+        if all_items.len() >= total.max(0) as usize {
+            fully_fetched = true;
+        }
+    }
+
+    let response = if had_counted_response {
+        ItemsResponseVariants::WithCount(ItemsResponseWithCount {
+            items: all_items,
+            total_record_count: 0,
+            start_index: 0,
+        })
+    } else {
+        ItemsResponseVariants::Bare(all_items)
+    };
+
+    Ok((response, upstream_total, fully_fetched))
 }
 
 async fn fetch_upstream_page_raw(
@@ -954,60 +1131,6 @@ async fn fetch_upstream_page_raw(
     )
     .await?;
     Ok(response)
-}
-
-async fn fetch_all_raw_items_from_server(
-    index: usize,
-    state: AppState,
-    request: reqwest::Request,
-    session: AuthorizationSession,
-    server: Server,
-) -> Result<(ItemsResponseVariants, Server), StatusCode> {
-    let first_page = fetch_upstream_page_raw(
-        index,
-        state.clone(),
-        request
-            .try_clone()
-            .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?,
-        session.clone(),
-        server.clone(),
-        0,
-    )
-    .await?;
-
-    let had_counted_response = matches!(&first_page, ItemsResponseVariants::WithCount(_));
-    let first_page_len = first_page.len();
-    let mut all_items = first_page.into_items();
-
-    let extra_pages = if should_continue_upstream_fetch(first_page_len, UPSTREAM_PAGE_SIZE) {
-        fetch_remaining_upstream_pages(
-            index,
-            state.clone(),
-            &request,
-            session.clone(),
-            server.clone(),
-            first_page_len,
-        )
-        .await?
-    } else {
-        Vec::new()
-    };
-
-    for (_, page) in extra_pages {
-        all_items.extend(page.into_items());
-    }
-
-    let response = if had_counted_response {
-        ItemsResponseVariants::WithCount(ItemsResponseWithCount {
-            items: all_items,
-            total_record_count: 0,
-            start_index: 0,
-        })
-    } else {
-        ItemsResponseVariants::Bare(all_items)
-    };
-
-    Ok((response, server))
 }
 
 async fn fetch_upstream_pages_parallel(
@@ -1050,52 +1173,6 @@ async fn fetch_upstream_pages_parallel(
     }
 
     pages.sort_by_key(|(start_index, _)| *start_index);
-    Ok(pages)
-}
-
-async fn fetch_remaining_upstream_pages(
-    index: usize,
-    state: AppState,
-    request: &reqwest::Request,
-    session: AuthorizationSession,
-    server: Server,
-    first_page_len: usize,
-) -> Result<Vec<(usize, ItemsResponseVariants)>, StatusCode> {
-    let mut pages = Vec::new();
-    let mut next_start = first_page_len;
-
-    loop {
-        let batch_starts: Vec<usize> = (0..MAX_PARALLEL_UPSTREAM_PAGES)
-            .map(|offset| next_start + offset * UPSTREAM_PAGE_SIZE)
-            .collect();
-        let batch = fetch_upstream_pages_parallel(
-            index,
-            state.clone(),
-            request,
-            session.clone(),
-            server.clone(),
-            &batch_starts,
-        )
-        .await?;
-        let batch: Vec<(usize, ItemsResponseVariants)> = batch
-            .into_iter()
-            .filter(|(_, page)| page.len() > 0)
-            .collect();
-
-        if batch.is_empty() {
-            break;
-        }
-
-        let saw_partial = batch
-            .iter()
-            .any(|(_, page)| page.len() < UPSTREAM_PAGE_SIZE);
-        pages.extend(batch);
-        if saw_partial {
-            break;
-        }
-        next_start += MAX_PARALLEL_UPSTREAM_PAGES * UPSTREAM_PAGE_SIZE;
-    }
-
     Ok(pages)
 }
 
@@ -1527,6 +1604,60 @@ mod tests {
         let url = url::Url::parse("http://localhost/Items?Parent%49d=abc").unwrap();
 
         assert!(has_query_key(&url, &["ParentId"]));
+    }
+
+    #[test]
+    fn is_upstream_limited_catalog_request_detects_latest_and_suggestions() {
+        let latest = url::Url::parse(
+            "http://localhost/Users/u/Items/Latest?Limit=16&ParentId=abc",
+        )
+        .unwrap();
+        let suggestions =
+            url::Url::parse("http://localhost/Users/u/Items/Suggestions?Limit=12").unwrap();
+        let browse = url::Url::parse(
+            "http://localhost/Users/u/Items?Limit=100&ParentId=abc",
+        )
+        .unwrap();
+
+        assert!(is_upstream_limited_catalog_request(&latest));
+        assert!(is_upstream_limited_catalog_request(&suggestions));
+        assert!(!is_upstream_limited_catalog_request(&browse));
+    }
+
+    #[test]
+    fn merged_library_max_pages_scales_with_client_window() {
+        assert_eq!(
+            merged_library_max_pages(Pagination {
+                start_index: 0,
+                limit: Some(100),
+            }),
+            2
+        );
+        assert_eq!(
+            merged_library_max_pages(Pagination {
+                start_index: 100,
+                limit: Some(100),
+            }),
+            3
+        );
+        assert_eq!(
+            merged_library_max_pages(Pagination {
+                start_index: 0,
+                limit: None,
+            }),
+            MAX_MERGED_LIBRARY_PAGES
+        );
+    }
+
+    #[test]
+    fn estimate_merged_library_total_uses_exact_count_when_fully_fetched() {
+        assert_eq!(estimate_merged_library_total(42, 100, 500, true), 42);
+    }
+
+    #[test]
+    fn estimate_merged_library_total_scales_upstream_totals_when_windowed() {
+        assert_eq!(estimate_merged_library_total(80, 100, 1000, false), 800);
+        assert_eq!(estimate_merged_library_total(5, 10, 200, false), 100);
     }
 
     #[test]

--- a/crates/jellyswarrm-proxy/src/handlers/federated.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/federated.rs
@@ -19,7 +19,6 @@ use crate::{
     },
     processors::response_processor::ResponseProcessingProfile,
     request_preprocessing::{apply_to_request, JellyfinAuthorization, PreprocessedRequest},
-    server_id::ServerId,
     server_storage::Server,
     user_authorization_service::AuthorizationSession,
     AppState,
@@ -30,6 +29,8 @@ struct Pagination {
     start_index: usize,
     limit: Option<usize>,
 }
+
+type NamedMediaItemGroup = (String, Vec<(MediaItem, Server)>);
 
 fn extract_parent_id(url: &url::Url) -> Option<String> {
     url.query_pairs()
@@ -61,47 +62,96 @@ pub async fn get_items_from_all_servers_if_not_restricted(
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     let original_request = &preprocessed.original_request;
 
-    if state.merge_libraries_enabled().await {
-        if let Some(parent_id) = extract_parent_id(original_request.url()) {
-            match state.merged_library_service.resolve(&parent_id).await {
-                Ok(Some((lib, members))) if !members.is_empty() => {
-                    debug!(
-                        "ParentId {} is merged library '{}' — fanning out to {} servers",
-                        parent_id,
-                        lib.collection_type,
-                        members.len()
-                    );
-                    return get_items_for_merged_library(&state, preprocessed, members).await;
-                }
-                Ok(_) => {}
-                Err(e) => {
-                    error!("Failed to resolve merged library for {}: {}", parent_id, e);
-                }
-            }
-        }
-    } else if state.library_group_service.has_groups().await.unwrap_or(false) {
-        if let Some(parent_id) = extract_parent_id(original_request.url()) {
-            if let Ok(Some((lib, members))) =
-                state.library_group_service.resolve(&state, &parent_id).await
-            {
-                if !members.is_empty() {
-                    debug!(
-                        "ParentId {} is custom library group '{}' — fanning out to {} servers",
-                        parent_id,
-                        lib.name,
-                        members.len()
-                    );
-                    return get_items_for_merged_library(&state, preprocessed, members).await;
-                }
-            }
-        }
-    }
-
-    if has_query_key(original_request.url(), &["SeriesId", "ParentId"]) {
+    if has_query_key(original_request.url(), &["SeriesId"]) {
         return get_items(State(state), Preprocessed(preprocessed)).await;
     }
 
+    if let Some(parent_id) = extract_parent_id(original_request.url()) {
+        if is_single_virtual_library_parent(&state, &parent_id).await {
+            return get_items(State(state), Preprocessed(preprocessed)).await;
+        }
+    }
+
     get_items_from_all_servers_preprocessed(&state, preprocessed).await
+}
+
+async fn resolve_library_parent_members(
+    state: &AppState,
+    parent_id: &str,
+) -> Result<Option<Vec<MergedLibraryMember>>, StatusCode> {
+    if state.library_group_service.has_groups().await.unwrap_or(false) {
+        match state.library_group_service.resolve(state, parent_id).await {
+            Ok(Some((lib, members))) if !members.is_empty() => {
+                debug!(
+                    "ParentId {} is custom library group '{}' — fanning out to {} servers",
+                    parent_id,
+                    lib.name,
+                    members.len()
+                );
+                return Ok(Some(members));
+            }
+            Ok(_) => {}
+            Err(e) => {
+                error!(
+                    "Failed to resolve custom library group for {}: {}",
+                    parent_id, e
+                );
+                return Err(StatusCode::INTERNAL_SERVER_ERROR);
+            }
+        }
+    }
+
+    if state.merge_libraries_enabled().await {
+        match state.merged_library_service.resolve(parent_id).await {
+            Ok(Some((lib, members))) if !members.is_empty() => {
+                debug!(
+                    "ParentId {} is merged library '{}' — fanning out to {} servers",
+                    parent_id,
+                    lib.collection_type,
+                    members.len()
+                );
+                return Ok(Some(members));
+            }
+            Ok(_) => {}
+            Err(e) => {
+                error!("Failed to resolve merged library for {}: {}", parent_id, e);
+                return Err(StatusCode::INTERNAL_SERVER_ERROR);
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+async fn is_single_virtual_library_parent(state: &AppState, parent_id: &str) -> bool {
+    let parent_id = normalize_library_id(parent_id);
+    if state
+        .library_group_service
+        .get_group(&parent_id)
+        .await
+        .ok()
+        .flatten()
+        .is_some()
+    {
+        return false;
+    }
+    if state
+        .merged_library_service
+        .get_by_virtual_id(&parent_id)
+        .await
+        .ok()
+        .flatten()
+        .is_some()
+    {
+        return false;
+    }
+    state
+        .media_storage
+        .get_media_mapping_by_virtual(&parent_id)
+        .await
+        .ok()
+        .flatten()
+        .is_some()
 }
 
 async fn get_items_for_merged_library(
@@ -170,16 +220,16 @@ async fn get_items_for_merged_library(
         };
 
         *request.url_mut() = replace_parent_id(request.url(), &mapping.original_media_id);
+        ensure_dedup_fields(request.url_mut());
 
         let state_clone = state.clone();
         join_set.spawn(async move {
-            let result = fetch_items_from_server(
+            let result = fetch_all_items_from_server(
                 index,
                 state_clone,
                 request,
                 session,
                 server,
-                pagination,
                 false,
             )
             .await;
@@ -218,7 +268,7 @@ async fn get_items_for_merged_library(
     let wrapped_response = indexed_results
         .iter()
         .any(|(_, items)| matches!(items, ItemsResponseVariants::WithCount(_)));
-    let mut all_items: Vec<TaggedMediaItem> = indexed_results
+    let all_items: Vec<TaggedMediaItem> = indexed_results
         .into_iter()
         .flat_map(|(index, response)| {
             let Some(server) = member_servers.get(&index).cloned() else {
@@ -260,15 +310,29 @@ async fn get_items_from_all_servers_preprocessed(
     state: &AppState,
     preprocessed: PreprocessedRequest,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
-    if state.merge_libraries_enabled().await {
-        get_items_from_all_servers_with_merged_libraries(state, preprocessed).await
-    } else if state
+    if let Some(parent_id) = extract_parent_id(preprocessed.original_request.url()) {
+        match resolve_library_parent_members(state, &parent_id).await {
+            Ok(Some(members)) => {
+                return get_items_for_merged_library(state, preprocessed, members).await;
+            }
+            Ok(None) => {
+                if is_single_virtual_library_parent(state, &parent_id).await {
+                    return get_items(State(state.clone()), Preprocessed(preprocessed)).await;
+                }
+            }
+            Err(status) => return Err(status),
+        }
+    }
+
+    if state
         .library_group_service
         .has_groups()
         .await
         .unwrap_or(false)
     {
         get_items_from_all_servers_with_custom_library_groups(state, preprocessed).await
+    } else if state.merge_libraries_enabled().await {
+        get_items_from_all_servers_with_merged_libraries(state, preprocessed).await
     } else {
         get_items_from_all_servers_interleaved(state, preprocessed).await
     }
@@ -434,7 +498,7 @@ async fn get_items_from_all_servers_with_merged_libraries(
         .iter()
         .any(|(items, _)| matches!(items, ItemsResponseVariants::WithCount(_)));
     let mut library_groups: HashMap<String, Vec<(MediaItem, Server)>> = HashMap::new();
-    let mut non_lib_per_server: Vec<ItemsResponseVariants> = Vec::new();
+    let mut non_lib_per_server: Vec<(ItemsResponseVariants, Server)> = Vec::new();
     let mut live_tv_seen = false;
 
     for (raw_response, server) in server_raw {
@@ -475,7 +539,7 @@ async fn get_items_from_all_servers_with_merged_libraries(
             let processed =
                 process_media_items_for_server(non_library_items, state, &server, true).await?;
             if !processed.is_empty() {
-                non_lib_per_server.push(ItemsResponseVariants::Bare(processed));
+                non_lib_per_server.push((ItemsResponseVariants::Bare(processed), server));
             }
         }
     }
@@ -530,7 +594,7 @@ async fn get_items_from_all_servers_with_merged_libraries(
     });
 
     let mut final_items = library_items;
-    final_items.extend(interleave_items(non_lib_per_server));
+    final_items.extend(interleave_server_items(non_lib_per_server));
 
     let (paged_items, total_count) = apply_pagination(final_items, pagination);
     debug!(
@@ -627,10 +691,9 @@ async fn get_items_from_all_servers_with_custom_library_groups(
         .get_assignments()
         .await
         .unwrap_or_default();
-    let mut custom_library_groups: HashMap<String, (String, Vec<(MediaItem, Server)>)> =
-        HashMap::new();
+    let mut custom_library_groups: HashMap<String, NamedMediaItemGroup> = HashMap::new();
     let mut library_groups: HashMap<String, Vec<(MediaItem, Server)>> = HashMap::new();
-    let mut non_lib_per_server: Vec<ItemsResponseVariants> = Vec::new();
+    let mut non_lib_per_server: Vec<(ItemsResponseVariants, Server)> = Vec::new();
     let mut live_tv_seen = false;
 
     for (raw_response, server) in server_raw {
@@ -661,7 +724,7 @@ async fn get_items_from_all_servers_with_custom_library_groups(
                 }
 
                 library_groups
-                    .entry(format!("single:{}", original_library_id))
+                    .entry(format!("single:{}:{}", server.id, original_library_id))
                     .or_default()
                     .push((item, server.clone()));
             } else {
@@ -679,7 +742,7 @@ async fn get_items_from_all_servers_with_custom_library_groups(
             let processed =
                 process_media_items_for_server(non_library_items, state, &server, true).await?;
             if !processed.is_empty() {
-                non_lib_per_server.push(ItemsResponseVariants::Bare(processed));
+                non_lib_per_server.push((ItemsResponseVariants::Bare(processed), server));
             }
         }
     }
@@ -692,7 +755,7 @@ async fn get_items_from_all_servers_with_custom_library_groups(
         .into_iter()
         .map(|group| (group.virtual_id.clone(), group.sort_order))
         .collect();
-    let mut custom_group_entries: Vec<(String, (String, Vec<(MediaItem, Server)>))> =
+    let mut custom_group_entries: Vec<(String, NamedMediaItemGroup)> =
         custom_library_groups.into_iter().collect();
     custom_group_entries.sort_by(|left, right| {
         let left_order = group_sort_order.get(&left.0).copied().unwrap_or(0);
@@ -702,28 +765,34 @@ async fn get_items_from_all_servers_with_custom_library_groups(
             .then_with(|| left.1.0.cmp(&right.1.0))
     });
 
-    let mut library_items = Vec::new();
-
+    let mut library_join = JoinSet::new();
     for (group_virtual_id, (display_name, group)) in custom_group_entries {
         if group.is_empty() {
             continue;
         }
-
-        let merged_item = build_merged_library_item(
-            state,
-            group,
-            display_name,
-            group_virtual_id,
-            false,
-        )
-        .await?;
-        library_items.push(merged_item);
+        let state = state.clone();
+        library_join.spawn(async move {
+            build_merged_library_item(&state, group, display_name, group_virtual_id, false).await
+        });
     }
-
     for (_key, group) in library_groups {
         if let Some((item, server)) = group.into_iter().next() {
-            library_items
-                .push(process_media_item_for_server(item, state, &server, true).await?);
+            let state = state.clone();
+            library_join.spawn(async move {
+                process_library_folder(&state, item, &server, true).await
+            });
+        }
+    }
+
+    let mut library_items = Vec::new();
+    while let Some(result) = library_join.join_next().await {
+        match result {
+            Ok(Ok(item)) => library_items.push(item),
+            Ok(Err(status)) => return Err(status),
+            Err(e) => {
+                error!("Library folder processing failed: {:?}", e);
+                return Err(StatusCode::INTERNAL_SERVER_ERROR);
+            }
         }
     }
 
@@ -734,7 +803,26 @@ async fn get_items_from_all_servers_with_custom_library_groups(
     });
 
     let mut final_items = library_items;
-    final_items.extend(interleave_items(non_lib_per_server));
+    if is_playback_catalog_request(original_request.url()) {
+        let duplicate_config =
+            resolve_duplicate_policy(state, extract_parent_id(original_request.url()).as_deref())
+                .await;
+        let tagged: Vec<TaggedMediaItem> = non_lib_per_server
+            .into_iter()
+            .flat_map(|(items, server)| {
+                items
+                    .into_items()
+                    .into_iter()
+                    .map(move |item| TaggedMediaItem {
+                        item,
+                        server: server.clone(),
+                    })
+            })
+            .collect();
+        final_items.extend(deduplicate_tagged_items(tagged, &duplicate_config));
+    } else {
+        final_items.extend(interleave_server_items(non_lib_per_server));
+    }
 
     let (paged_items, total_count) = apply_pagination(final_items, pagination);
     debug!(
@@ -826,6 +914,138 @@ async fn fetch_items_from_server(
     Ok(items_response)
 }
 
+const UPSTREAM_PAGE_SIZE: usize = 100;
+
+async fn fetch_all_items_from_server(
+    index: usize,
+    state: AppState,
+    request: reqwest::Request,
+    session: AuthorizationSession,
+    server: Server,
+    should_change_name: bool,
+) -> Result<ItemsResponseVariants, StatusCode> {
+    let (mut items_response, server) =
+        fetch_all_raw_items_from_server(index, state.clone(), request, session, server).await?;
+    process_items_response_json(&mut items_response, &state, &server, should_change_name).await?;
+    Ok(items_response)
+}
+
+async fn fetch_all_raw_items_from_server(
+    index: usize,
+    state: AppState,
+    request: reqwest::Request,
+    session: AuthorizationSession,
+    server: Server,
+) -> Result<(ItemsResponseVariants, Server), StatusCode> {
+    let mut all_items = Vec::new();
+    let mut start_index = 0;
+    let mut had_counted_response = false;
+
+    loop {
+        let mut page_request = request
+            .try_clone()
+            .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+        set_upstream_page(page_request.url_mut(), start_index, UPSTREAM_PAGE_SIZE);
+
+        let (page, _server) = fetch_raw_items_from_server(
+            index,
+            state.clone(),
+            page_request,
+            session.clone(),
+            server.clone(),
+            Pagination {
+                start_index: 0,
+                limit: None,
+            },
+        )
+        .await?;
+
+        let page_len = page.len();
+        if matches!(&page, ItemsResponseVariants::WithCount(_)) {
+            had_counted_response = true;
+        }
+        all_items.extend(page.into_items());
+
+        if !should_continue_upstream_fetch(page_len, UPSTREAM_PAGE_SIZE) {
+            break;
+        }
+        start_index += page_len;
+    }
+
+    let response = if had_counted_response {
+        ItemsResponseVariants::WithCount(ItemsResponseWithCount {
+            items: all_items,
+            total_record_count: 0,
+            start_index: 0,
+        })
+    } else {
+        ItemsResponseVariants::Bare(all_items)
+    };
+
+    Ok((response, server))
+}
+
+fn set_upstream_page(url: &mut url::Url, start_index: usize, limit: usize) {
+    let pairs = url
+        .query_pairs()
+        .filter(|(key, _)| !is_pagination_key(key))
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect::<Vec<_>>();
+
+    let mut query = url.query_pairs_mut();
+    query.clear().extend_pairs(pairs);
+    query
+        .append_pair("StartIndex", &start_index.to_string())
+        .append_pair("Limit", &limit.to_string());
+}
+
+fn should_continue_upstream_fetch(page_len: usize, page_size: usize) -> bool {
+    page_len >= page_size
+}
+
+fn ensure_dedup_fields(url: &mut url::Url) {
+    const REQUIRED_FIELDS: &[&str] = &["ChildCount", "ProviderIds"];
+    let pairs = url
+        .query_pairs()
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect::<Vec<_>>();
+    let mut fields = pairs
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case("Fields"))
+        .map(|(_, value)| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|field| !field.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    for required_field in REQUIRED_FIELDS {
+        if !fields
+            .iter()
+            .any(|field| field.eq_ignore_ascii_case(required_field))
+        {
+            fields.push((*required_field).to_string());
+        }
+    }
+    let fields_value = fields.join(",");
+    let mut wrote_fields = false;
+    let mut query = url.query_pairs_mut();
+    query.clear();
+    for (key, value) in pairs {
+        if key.eq_ignore_ascii_case("Fields") {
+            query.append_pair("Fields", &fields_value);
+            wrote_fields = true;
+        } else {
+            query.append_pair(&key, &value);
+        }
+    }
+    if !wrote_fields {
+        query.append_pair("Fields", &fields_value);
+    }
+}
+
 async fn fetch_raw_items_from_server(
     index: usize,
     state: AppState,
@@ -912,6 +1132,10 @@ async fn build_merged_library_item(
     let mut template = None;
     let mut total_child_count = 0;
 
+    let primary_tag = group
+        .first()
+        .and_then(|(item, _)| item.image_tags.as_ref()?.get("Primary").cloned());
+
     for (item, server) in &group {
         total_child_count += item.child_count.unwrap_or(0);
         let processed = process_media_item_for_server(item.clone(), state, server, false).await?;
@@ -938,21 +1162,52 @@ async fn build_merged_library_item(
     item.name = Some(display_name.clone());
     item.sort_name = Some(display_name.to_lowercase());
     item.child_count = Some(total_child_count);
-    attach_library_folder_image_source(&mut item, &image_source_id);
+    attach_library_folder_image_source(&mut item, &image_source_id, primary_tag.as_deref());
     Ok(item)
 }
 
-fn attach_library_folder_image_source(item: &mut MediaItem, image_source_id: &str) {
-    let Some(image_tags) = item.image_tags.as_mut() else {
+async fn process_library_folder(
+    state: &AppState,
+    item: MediaItem,
+    server: &Server,
+    should_change_name: bool,
+) -> Result<MediaItem, StatusCode> {
+    let primary_tag = item
+        .image_tags
+        .as_ref()
+        .and_then(|tags| tags.get("Primary").cloned());
+    let mut processed =
+        process_media_item_for_server(item, state, server, should_change_name).await?;
+    let image_source_id = processed.id.clone();
+    attach_library_folder_image_source(
+        &mut processed,
+        &image_source_id,
+        primary_tag.as_deref(),
+    );
+    Ok(processed)
+}
+
+fn attach_library_folder_image_source(
+    item: &mut MediaItem,
+    image_source_id: &str,
+    primary_tag: Option<&str>,
+) {
+    let Some(primary_tag) = primary_tag
+        .map(str::to_string)
+        .or_else(|| {
+            item.image_tags
+                .as_ref()
+                .and_then(|tags| tags.get("Primary").cloned())
+        })
+    else {
         return;
     };
 
-    let Some(primary_tag) = image_tags.remove("Primary") else {
-        return;
-    };
-
-    if image_tags.is_empty() {
-        item.image_tags = None;
+    if let Some(image_tags) = item.image_tags.as_mut() {
+        image_tags.remove("Primary");
+        if image_tags.is_empty() {
+            item.image_tags = None;
+        }
     }
 
     item.extra.insert(
@@ -961,8 +1216,23 @@ fn attach_library_folder_image_source(item: &mut MediaItem, image_source_id: &st
     );
     item.extra.insert(
         "PrimaryImageTag".to_string(),
-        serde_json::Value::String(primary_tag),
+        serde_json::Value::String(primary_tag.clone()),
     );
+    item.image_tags = Some(HashMap::from([("Primary".to_string(), primary_tag)]));
+}
+
+fn is_playback_catalog_request(url: &url::Url) -> bool {
+    let path = url.path().to_ascii_lowercase();
+    path.contains("/nextup") || path.contains("/resume")
+}
+
+fn interleave_server_items(server_items: Vec<(ItemsResponseVariants, Server)>) -> Vec<MediaItem> {
+    interleave_items(
+        server_items
+            .into_iter()
+            .map(|(items, _)| items)
+            .collect(),
+    )
 }
 
 async fn process_media_item_for_server(
@@ -1109,7 +1379,8 @@ async fn resolve_duplicate_policy(
     parent_id: Option<&str>,
 ) -> DuplicatePolicyConfig {
     if let Some(parent_id) = parent_id {
-        if let Ok(Some(group)) = state.library_group_service.get_group(parent_id).await {
+        let parent_id = normalize_library_id(parent_id);
+        if let Ok(Some(group)) = state.library_group_service.get_group(&parent_id).await {
             return DuplicatePolicyConfig {
                 policy: group.duplicate_policy,
                 preferred_server_id: group.preferred_server_id,
@@ -1118,7 +1389,7 @@ async fn resolve_duplicate_policy(
     }
 
     DuplicatePolicyConfig {
-        policy: DuplicatePolicy::ShowAll,
+        policy: DuplicatePolicy::ServerPriority,
         preferred_server_id: None,
     }
 }
@@ -1468,9 +1739,15 @@ mod tests {
             "tag-123".to_string(),
         )]));
 
-        super::attach_library_folder_image_source(&mut item, "source-library-id");
+        super::attach_library_folder_image_source(&mut item, "source-library-id", Some("tag-123"));
 
-        assert!(item.image_tags.is_none());
+        assert_eq!(
+            item.image_tags
+                .as_ref()
+                .and_then(|tags| tags.get("Primary"))
+                .map(String::as_str),
+            Some("tag-123")
+        );
         assert_eq!(
             item.extra.get("PrimaryImageItemId"),
             Some(&json!("source-library-id"))

--- a/crates/jellyswarrm-proxy/src/handlers/federated.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/federated.rs
@@ -915,6 +915,7 @@ async fn fetch_items_from_server(
 }
 
 const UPSTREAM_PAGE_SIZE: usize = 100;
+const MAX_PARALLEL_UPSTREAM_PAGES: usize = 8;
 
 async fn fetch_all_items_from_server(
     index: usize,
@@ -930,6 +931,31 @@ async fn fetch_all_items_from_server(
     Ok(items_response)
 }
 
+async fn fetch_upstream_page_raw(
+    index: usize,
+    state: AppState,
+    request: reqwest::Request,
+    session: AuthorizationSession,
+    server: Server,
+    start_index: usize,
+) -> Result<ItemsResponseVariants, StatusCode> {
+    let mut request = request;
+    set_upstream_page(request.url_mut(), start_index, UPSTREAM_PAGE_SIZE);
+    let (response, _) = fetch_raw_items_from_server(
+        index,
+        state,
+        request,
+        session,
+        server,
+        Pagination {
+            start_index: 0,
+            limit: None,
+        },
+    )
+    .await?;
+    Ok(response)
+}
+
 async fn fetch_all_raw_items_from_server(
     index: usize,
     state: AppState,
@@ -937,39 +963,38 @@ async fn fetch_all_raw_items_from_server(
     session: AuthorizationSession,
     server: Server,
 ) -> Result<(ItemsResponseVariants, Server), StatusCode> {
-    let mut all_items = Vec::new();
-    let mut start_index = 0;
-    let mut had_counted_response = false;
-
-    loop {
-        let mut page_request = request
+    let first_page = fetch_upstream_page_raw(
+        index,
+        state.clone(),
+        request
             .try_clone()
-            .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
-        set_upstream_page(page_request.url_mut(), start_index, UPSTREAM_PAGE_SIZE);
+            .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?,
+        session.clone(),
+        server.clone(),
+        0,
+    )
+    .await?;
 
-        let (page, _server) = fetch_raw_items_from_server(
+    let had_counted_response = matches!(&first_page, ItemsResponseVariants::WithCount(_));
+    let first_page_len = first_page.len();
+    let mut all_items = first_page.into_items();
+
+    let extra_pages = if should_continue_upstream_fetch(first_page_len, UPSTREAM_PAGE_SIZE) {
+        fetch_remaining_upstream_pages(
             index,
             state.clone(),
-            page_request,
+            &request,
             session.clone(),
             server.clone(),
-            Pagination {
-                start_index: 0,
-                limit: None,
-            },
+            first_page_len,
         )
-        .await?;
+        .await?
+    } else {
+        Vec::new()
+    };
 
-        let page_len = page.len();
-        if matches!(&page, ItemsResponseVariants::WithCount(_)) {
-            had_counted_response = true;
-        }
+    for (_, page) in extra_pages {
         all_items.extend(page.into_items());
-
-        if !should_continue_upstream_fetch(page_len, UPSTREAM_PAGE_SIZE) {
-            break;
-        }
-        start_index += page_len;
     }
 
     let response = if had_counted_response {
@@ -983,6 +1008,95 @@ async fn fetch_all_raw_items_from_server(
     };
 
     Ok((response, server))
+}
+
+async fn fetch_upstream_pages_parallel(
+    index: usize,
+    state: AppState,
+    request: &reqwest::Request,
+    session: AuthorizationSession,
+    server: Server,
+    page_starts: &[usize],
+) -> Result<Vec<(usize, ItemsResponseVariants)>, StatusCode> {
+    let mut pages = Vec::with_capacity(page_starts.len());
+    for chunk in page_starts.chunks(MAX_PARALLEL_UPSTREAM_PAGES) {
+        let mut join_set = JoinSet::new();
+        for &start_index in chunk {
+            let state = state.clone();
+            let request = request
+                .try_clone()
+                .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+            let session = session.clone();
+            let server = server.clone();
+            join_set.spawn(async move {
+                let page = fetch_upstream_page_raw(
+                    index, state, request, session, server, start_index,
+                )
+                .await?;
+                Ok::<_, StatusCode>((start_index, page))
+            });
+        }
+
+        while let Some(result) = join_set.join_next().await {
+            match result {
+                Ok(Ok((start_index, page))) => pages.push((start_index, page)),
+                Ok(Err(status)) => return Err(status),
+                Err(error) => {
+                    error!("Parallel upstream page fetch failed: {:?}", error);
+                    return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                }
+            }
+        }
+    }
+
+    pages.sort_by_key(|(start_index, _)| *start_index);
+    Ok(pages)
+}
+
+async fn fetch_remaining_upstream_pages(
+    index: usize,
+    state: AppState,
+    request: &reqwest::Request,
+    session: AuthorizationSession,
+    server: Server,
+    first_page_len: usize,
+) -> Result<Vec<(usize, ItemsResponseVariants)>, StatusCode> {
+    let mut pages = Vec::new();
+    let mut next_start = first_page_len;
+
+    loop {
+        let batch_starts: Vec<usize> = (0..MAX_PARALLEL_UPSTREAM_PAGES)
+            .map(|offset| next_start + offset * UPSTREAM_PAGE_SIZE)
+            .collect();
+        let batch = fetch_upstream_pages_parallel(
+            index,
+            state.clone(),
+            request,
+            session.clone(),
+            server.clone(),
+            &batch_starts,
+        )
+        .await?;
+        let batch: Vec<(usize, ItemsResponseVariants)> = batch
+            .into_iter()
+            .filter(|(_, page)| page.len() > 0)
+            .collect();
+
+        if batch.is_empty() {
+            break;
+        }
+
+        let saw_partial = batch
+            .iter()
+            .any(|(_, page)| page.len() < UPSTREAM_PAGE_SIZE);
+        pages.extend(batch);
+        if saw_partial {
+            break;
+        }
+        next_start += MAX_PARALLEL_UPSTREAM_PAGES * UPSTREAM_PAGE_SIZE;
+    }
+
+    Ok(pages)
 }
 
 fn set_upstream_page(url: &mut url::Url, start_index: usize, limit: usize) {

--- a/crates/jellyswarrm-proxy/src/handlers/federated.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/federated.rs
@@ -5,11 +5,13 @@ use tokio::task::JoinSet;
 use tracing::{debug, error, trace, warn};
 
 use crate::{
+    duplicate_policy::{deduplicate_tagged_items, DuplicatePolicy, DuplicatePolicyConfig, TaggedMediaItem},
     extractors::Preprocessed,
     handlers::{
         common::{execute_json_request, response_json_to_payload},
         items::get_items,
     },
+    library_group_service::{normalize_library_id, LibraryAssignment},
     merged_library_service::MergedLibraryMember,
     models::{
         enums::{BaseItemKind, CollectionType},
@@ -17,6 +19,7 @@ use crate::{
     },
     processors::response_processor::ResponseProcessingProfile,
     request_preprocessing::{apply_to_request, JellyfinAuthorization, PreprocessedRequest},
+    server_id::ServerId,
     server_storage::Server,
     user_authorization_service::AuthorizationSession,
     AppState,
@@ -76,6 +79,22 @@ pub async fn get_items_from_all_servers_if_not_restricted(
                 }
             }
         }
+    } else if state.library_group_service.has_groups().await.unwrap_or(false) {
+        if let Some(parent_id) = extract_parent_id(original_request.url()) {
+            if let Ok(Some((lib, members))) =
+                state.library_group_service.resolve(&state, &parent_id).await
+            {
+                if !members.is_empty() {
+                    debug!(
+                        "ParentId {} is custom library group '{}' — fanning out to {} servers",
+                        parent_id,
+                        lib.name,
+                        members.len()
+                    );
+                    return get_items_for_merged_library(&state, preprocessed, members).await;
+                }
+            }
+        }
     }
 
     if has_query_key(original_request.url(), &["SeriesId", "ParentId"]) {
@@ -97,8 +116,11 @@ async fn get_items_for_merged_library(
     }
 
     let pagination = pagination_from_url(original_request.url());
+    let parent_id = extract_parent_id(original_request.url());
+    let duplicate_config = resolve_duplicate_policy(state, parent_id.as_deref()).await;
     let mut join_set = JoinSet::new();
     let mut failures = 0;
+    let mut member_servers: HashMap<usize, Server> = HashMap::new();
 
     for (index, member) in members.into_iter().enumerate() {
         let resolved = state
@@ -135,6 +157,8 @@ async fn get_items_for_merged_library(
             failures += 1;
             continue;
         };
+
+        member_servers.insert(index, server.clone());
 
         let mut request = match original_request.try_clone() {
             Some(request) => request,
@@ -194,10 +218,22 @@ async fn get_items_for_merged_library(
     let wrapped_response = indexed_results
         .iter()
         .any(|(_, items)| matches!(items, ItemsResponseVariants::WithCount(_)));
-    let mut all_items = indexed_results
+    let mut all_items: Vec<TaggedMediaItem> = indexed_results
         .into_iter()
-        .flat_map(|(_, response)| response.into_items())
-        .collect::<Vec<_>>();
+        .flat_map(|(index, response)| {
+            let Some(server) = member_servers.get(&index).cloned() else {
+                error!("Missing server mapping for merged fan-out index {}", index);
+                return Vec::new();
+            };
+            response
+                .into_items()
+                .into_iter()
+                .map(move |item| TaggedMediaItem { item, server: server.clone() })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    let mut all_items = deduplicate_tagged_items(all_items, &duplicate_config);
     all_items.sort_by(|a, b| {
         let left = a.sort_name.as_deref().or(a.name.as_deref()).unwrap_or("");
         let right = b.sort_name.as_deref().or(b.name.as_deref()).unwrap_or("");
@@ -226,6 +262,13 @@ async fn get_items_from_all_servers_preprocessed(
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     if state.merge_libraries_enabled().await {
         get_items_from_all_servers_with_merged_libraries(state, preprocessed).await
+    } else if state
+        .library_group_service
+        .has_groups()
+        .await
+        .unwrap_or(false)
+    {
+        get_items_from_all_servers_with_custom_library_groups(state, preprocessed).await
     } else {
         get_items_from_all_servers_interleaved(state, preprocessed).await
     }
@@ -469,33 +512,218 @@ async fn get_items_from_all_servers_with_merged_libraries(
             }
         };
 
-        let mut members = Vec::new();
-        let mut template = None;
-        let mut total_child_count = 0;
+        let merged_item = build_merged_library_item(
+            state,
+            group,
+            display_name,
+            merged.virtual_id,
+            true,
+        )
+        .await?;
+        library_items.push(merged_item);
+    }
 
-        for (item, server) in &group {
-            total_child_count += item.child_count.unwrap_or(0);
-            let processed =
-                process_media_item_for_server(item.clone(), state, server, false).await?;
-            members.push((server.url.to_string(), processed.id.clone()));
-            if template.is_none() {
-                template = Some(processed);
+    library_items.sort_by(|a, b| {
+        let left = a.name.as_deref().unwrap_or("");
+        let right = b.name.as_deref().unwrap_or("");
+        left.cmp(right)
+    });
+
+    let mut final_items = library_items;
+    final_items.extend(interleave_items(non_lib_per_server));
+
+    let (paged_items, total_count) = apply_pagination(final_items, pagination);
+    debug!(
+        "Returning {} of {} federated items",
+        paged_items.len(),
+        total_count
+    );
+
+    items_response_to_json(items_response_from_shape(
+        paged_items,
+        total_count,
+        pagination,
+        wrapped_response,
+    ))
+}
+
+async fn get_items_from_all_servers_with_custom_library_groups(
+    state: &AppState,
+    preprocessed: PreprocessedRequest,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let original_request = preprocessed.original_request;
+    let sessions = preprocessed.sessions.ok_or(StatusCode::UNAUTHORIZED)?;
+    if sessions.is_empty() {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    let pagination = pagination_from_url(original_request.url());
+    let mut join_set = JoinSet::new();
+    let mut failures = 0;
+
+    for (index, (session, server)) in sessions.into_iter().enumerate() {
+        let request = match original_request.try_clone() {
+            Some(request) => request,
+            None => {
+                error!("Failed to clone request for server: {}", server.name);
+                failures += 1;
+                continue;
+            }
+        };
+
+        let state_clone = state.clone();
+        join_set.spawn(async move {
+            let result = fetch_raw_items_from_server(
+                index,
+                state_clone,
+                request,
+                session,
+                server,
+                pagination,
+            )
+            .await;
+            (index, result)
+        });
+    }
+
+    let mut indexed_raw: Vec<(usize, (ItemsResponseVariants, Server))> = Vec::new();
+    while let Some(result) = join_set.join_next().await {
+        match result {
+            Ok((index, Ok(raw))) => indexed_raw.push((index, raw)),
+            Ok((_, Err(e))) => {
+                failures += 1;
+                error!("Federated server request failed: {:?}", e);
+            }
+            Err(e) => {
+                failures += 1;
+                error!("Task failed: {:?}", e);
+            }
+        }
+    }
+
+    if indexed_raw.is_empty() {
+        error!("All federated server requests failed");
+        return Err(StatusCode::BAD_GATEWAY);
+    }
+
+    if failures > 0 {
+        warn!(
+            "Returning partial federated response after {} server failure(s)",
+            failures
+        );
+    }
+
+    indexed_raw.sort_by_key(|(index, _)| *index);
+
+    let server_raw = indexed_raw
+        .into_iter()
+        .map(|(_, raw)| raw)
+        .collect::<Vec<_>>();
+    let wrapped_response = server_raw
+        .iter()
+        .any(|(items, _)| matches!(items, ItemsResponseVariants::WithCount(_)));
+    let custom_assignments = state
+        .library_group_service
+        .get_assignments()
+        .await
+        .unwrap_or_default();
+    let mut custom_library_groups: HashMap<String, (String, Vec<(MediaItem, Server)>)> =
+        HashMap::new();
+    let mut library_groups: HashMap<String, Vec<(MediaItem, Server)>> = HashMap::new();
+    let mut non_lib_per_server: Vec<ItemsResponseVariants> = Vec::new();
+    let mut live_tv_seen = false;
+
+    for (raw_response, server) in server_raw {
+        let mut non_library_items = Vec::new();
+
+        for item in raw_response.into_items() {
+            let is_mergeable = matches!(
+                item.item_type,
+                BaseItemKind::UserView | BaseItemKind::CollectionFolder
+            ) && item
+                .collection_type
+                .as_ref()
+                .is_some_and(|collection_type| *collection_type != CollectionType::LiveTv);
+
+            if is_mergeable {
+                let original_library_id = normalize_library_id(&item.id);
+                if let Some(LibraryAssignment {
+                    group_virtual_id,
+                    group_name,
+                }) = custom_assignments.get(&(server.id, original_library_id.clone()))
+                {
+                    custom_library_groups
+                        .entry(group_virtual_id.clone())
+                        .or_insert_with(|| (group_name.clone(), Vec::new()))
+                        .1
+                        .push((item, server.clone()));
+                    continue;
+                }
+
+                library_groups
+                    .entry(format!("single:{}", original_library_id))
+                    .or_default()
+                    .push((item, server.clone()));
+            } else {
+                if is_live_tv_user_view(&item) {
+                    if live_tv_seen {
+                        continue;
+                    }
+                    live_tv_seen = true;
+                }
+                non_library_items.push(item);
             }
         }
 
-        if let Err(e) = state
-            .merged_library_service
-            .upsert_members(&merged.virtual_id, &members)
-            .await
-        {
-            error!("Failed to upsert merged library members: {}", e);
+        if !non_library_items.is_empty() {
+            let processed =
+                process_media_items_for_server(non_library_items, state, &server, true).await?;
+            if !processed.is_empty() {
+                non_lib_per_server.push(ItemsResponseVariants::Bare(processed));
+            }
+        }
+    }
+
+    let group_sort_order: HashMap<String, i32> = state
+        .library_group_service
+        .list_groups()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|group| (group.virtual_id.clone(), group.sort_order))
+        .collect();
+    let mut custom_group_entries: Vec<(String, (String, Vec<(MediaItem, Server)>))> =
+        custom_library_groups.into_iter().collect();
+    custom_group_entries.sort_by(|left, right| {
+        let left_order = group_sort_order.get(&left.0).copied().unwrap_or(0);
+        let right_order = group_sort_order.get(&right.0).copied().unwrap_or(0);
+        left_order
+            .cmp(&right_order)
+            .then_with(|| left.1.0.cmp(&right.1.0))
+    });
+
+    let mut library_items = Vec::new();
+
+    for (group_virtual_id, (display_name, group)) in custom_group_entries {
+        if group.is_empty() {
+            continue;
         }
 
-        if let Some(mut item) = template {
-            item.id = merged.virtual_id.clone();
-            item.name = Some(display_name);
-            item.child_count = Some(total_child_count);
-            library_items.push(item);
+        let merged_item = build_merged_library_item(
+            state,
+            group,
+            display_name,
+            group_virtual_id,
+            false,
+        )
+        .await?;
+        library_items.push(merged_item);
+    }
+
+    for (_key, group) in library_groups {
+        if let Some((item, server)) = group.into_iter().next() {
+            library_items
+                .push(process_media_item_for_server(item, state, &server, true).await?);
         }
     }
 
@@ -673,6 +901,70 @@ async fn process_media_items_for_server(
     Ok(processed)
 }
 
+async fn build_merged_library_item(
+    state: &AppState,
+    group: Vec<(MediaItem, Server)>,
+    display_name: String,
+    virtual_id: String,
+    persist_members: bool,
+) -> Result<MediaItem, StatusCode> {
+    let mut members = Vec::new();
+    let mut template = None;
+    let mut total_child_count = 0;
+
+    for (item, server) in &group {
+        total_child_count += item.child_count.unwrap_or(0);
+        let processed = process_media_item_for_server(item.clone(), state, server, false).await?;
+        members.push((server.url.to_string(), processed.id.clone()));
+        if template.is_none() {
+            template = Some(processed);
+        }
+    }
+
+    if persist_members {
+        if let Err(e) = state
+            .merged_library_service
+            .upsert_members(&virtual_id, &members)
+            .await
+        {
+            error!("Failed to upsert merged library members: {}", e);
+        }
+    }
+
+    let mut item = template.ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+    let image_source_id = item.id.clone();
+    item.id = virtual_id.clone();
+    item.display_preferences_id = Some(virtual_id);
+    item.name = Some(display_name.clone());
+    item.sort_name = Some(display_name.to_lowercase());
+    item.child_count = Some(total_child_count);
+    attach_library_folder_image_source(&mut item, &image_source_id);
+    Ok(item)
+}
+
+fn attach_library_folder_image_source(item: &mut MediaItem, image_source_id: &str) {
+    let Some(image_tags) = item.image_tags.as_mut() else {
+        return;
+    };
+
+    let Some(primary_tag) = image_tags.remove("Primary") else {
+        return;
+    };
+
+    if image_tags.is_empty() {
+        item.image_tags = None;
+    }
+
+    item.extra.insert(
+        "PrimaryImageItemId".to_string(),
+        serde_json::Value::String(image_source_id.to_string()),
+    );
+    item.extra.insert(
+        "PrimaryImageTag".to_string(),
+        serde_json::Value::String(primary_tag),
+    );
+}
+
 async fn process_media_item_for_server(
     item: MediaItem,
     state: &AppState,
@@ -810,6 +1102,25 @@ fn apply_pagination(items: Vec<MediaItem>, pagination: Pagination) -> (Vec<Media
 
 fn to_i32(value: usize) -> i32 {
     value.min(i32::MAX as usize) as i32
+}
+
+async fn resolve_duplicate_policy(
+    state: &AppState,
+    parent_id: Option<&str>,
+) -> DuplicatePolicyConfig {
+    if let Some(parent_id) = parent_id {
+        if let Ok(Some(group)) = state.library_group_service.get_group(parent_id).await {
+            return DuplicatePolicyConfig {
+                policy: group.duplicate_policy,
+                preferred_server_id: group.preferred_server_id,
+            };
+        }
+    }
+
+    DuplicatePolicyConfig {
+        policy: DuplicatePolicy::ShowAll,
+        preferred_server_id: None,
+    }
 }
 
 #[cfg(test)]
@@ -1147,5 +1458,23 @@ mod tests {
         }
 
         serde_json::from_value(item).unwrap()
+    }
+
+    #[test]
+    fn attach_library_folder_image_source_points_client_at_source_library() {
+        let mut item = typed_media_item("group-id", "CollectionFolder", Some("movies"));
+        item.image_tags = Some(std::collections::HashMap::from([(
+            "Primary".to_string(),
+            "tag-123".to_string(),
+        )]));
+
+        super::attach_library_folder_image_source(&mut item, "source-library-id");
+
+        assert!(item.image_tags.is_none());
+        assert_eq!(
+            item.extra.get("PrimaryImageItemId"),
+            Some(&json!("source-library-id"))
+        );
+        assert_eq!(item.extra.get("PrimaryImageTag"), Some(&json!("tag-123")));
     }
 }

--- a/crates/jellyswarrm-proxy/src/handlers/quick_connect.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/quick_connect.rs
@@ -708,7 +708,10 @@ mod tests {
             server_storage: Arc::new(ServerStorageService::new(pool.clone())),
             media_storage: Arc::new(MediaStorageService::new(pool.clone())),
             merged_library_service: Arc::new(
-                crate::merged_library_service::MergedLibraryService::new(pool),
+                crate::merged_library_service::MergedLibraryService::new(pool.clone()),
+            ),
+            library_group_service: Arc::new(
+                crate::library_group_service::LibraryGroupService::new(pool),
             ),
             play_sessions: Arc::new(SessionStorage::new()),
             config: Arc::new(tokio::sync::RwLock::new(AppConfig::default())),

--- a/crates/jellyswarrm-proxy/src/library_group_service.rs
+++ b/crates/jellyswarrm-proxy/src/library_group_service.rs
@@ -1,0 +1,362 @@
+use std::collections::HashMap;
+
+use sqlx::SqlitePool;
+use tracing::debug;
+use uuid::Uuid;
+
+use crate::{
+    merged_library_service::MergedLibraryMember,
+    server_id::ServerId,
+    AppState,
+};
+
+pub fn normalize_library_id(id: &str) -> String {
+    match Uuid::parse_str(id) {
+        Ok(uuid) => uuid.simple().to_string(),
+        Err(_) => id.to_string(),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LibraryGroup {
+    pub virtual_id: String,
+    pub name: String,
+    pub sort_order: i32,
+    pub duplicate_policy: crate::duplicate_policy::DuplicatePolicy,
+    pub preferred_server_id: Option<ServerId>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LibraryGroupMemberRecord {
+    pub group_virtual_id: String,
+    pub server_id: ServerId,
+    pub original_library_id: String,
+    pub library_name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct LibraryAssignment {
+    pub group_virtual_id: String,
+    pub group_name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct LibraryGroupService {
+    pool: SqlitePool,
+}
+
+impl LibraryGroupService {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn has_groups(&self) -> Result<bool, sqlx::Error> {
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM library_groups")
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(count > 0)
+    }
+
+    pub async fn list_groups(&self) -> Result<Vec<LibraryGroup>, sqlx::Error> {
+        let rows: Vec<(String, String, i32, String, Option<i64>)> = sqlx::query_as(
+            "SELECT virtual_id, name, sort_order, duplicate_policy, preferred_server_id \
+             FROM library_groups ORDER BY sort_order, name",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(
+                |(virtual_id, name, sort_order, duplicate_policy, preferred_server_id)| {
+                    LibraryGroup {
+                        virtual_id,
+                        name,
+                        sort_order,
+                        duplicate_policy: duplicate_policy
+                            .parse()
+                            .unwrap_or(crate::duplicate_policy::DuplicatePolicy::ShowAll),
+                        preferred_server_id: preferred_server_id.map(ServerId::new),
+                    }
+                },
+            )
+            .collect())
+    }
+
+    pub async fn create_group(&self, name: &str) -> Result<LibraryGroup, sqlx::Error> {
+        let virtual_id = Uuid::new_v4().simple().to_string();
+        let sort_order: i64 = sqlx::query_scalar("SELECT COALESCE(MAX(sort_order), -1) + 1 FROM library_groups")
+            .fetch_one(&self.pool)
+            .await?;
+
+        sqlx::query(
+            "INSERT INTO library_groups (virtual_id, name, sort_order) VALUES (?, ?, ?)",
+        )
+        .bind(&virtual_id)
+        .bind(name.trim())
+        .bind(sort_order as i32)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(LibraryGroup {
+            virtual_id,
+            name: name.trim().to_string(),
+            sort_order: sort_order as i32,
+            duplicate_policy: crate::duplicate_policy::DuplicatePolicy::ShowAll,
+            preferred_server_id: None,
+        })
+    }
+
+    pub async fn update_group_policy(
+        &self,
+        virtual_id: &str,
+        duplicate_policy: crate::duplicate_policy::DuplicatePolicy,
+        preferred_server_id: Option<ServerId>,
+    ) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            "UPDATE library_groups SET duplicate_policy = ?, preferred_server_id = ? WHERE virtual_id = ?",
+        )
+        .bind(duplicate_policy.to_string())
+        .bind(preferred_server_id.map(|id| id.as_i64()))
+        .bind(virtual_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn rename_group(&self, virtual_id: &str, name: &str) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query("UPDATE library_groups SET name = ? WHERE virtual_id = ?")
+            .bind(name.trim())
+            .bind(virtual_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn delete_group(&self, virtual_id: &str) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query("DELETE FROM library_groups WHERE virtual_id = ?")
+            .bind(virtual_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn add_member(
+        &self,
+        group_virtual_id: &str,
+        server_id: ServerId,
+        original_library_id: &str,
+        library_name: &str,
+    ) -> Result<(), sqlx::Error> {
+        let original_library_id = normalize_library_id(original_library_id);
+
+        sqlx::query(
+            "DELETE FROM library_group_members WHERE server_id = ? AND original_library_id = ?",
+        )
+        .bind(server_id.as_i64())
+        .bind(&original_library_id)
+        .execute(&self.pool)
+        .await?;
+
+        sqlx::query(
+            "INSERT INTO library_group_members \
+             (group_virtual_id, server_id, original_library_id, library_name) \
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(group_virtual_id)
+        .bind(server_id.as_i64())
+        .bind(&original_library_id)
+        .bind(library_name.trim())
+        .execute(&self.pool)
+        .await?;
+
+        debug!(
+            "Assigned library {} on server {} to group {}",
+            original_library_id, server_id, group_virtual_id
+        );
+        Ok(())
+    }
+
+    pub async fn remove_member(
+        &self,
+        group_virtual_id: &str,
+        server_id: ServerId,
+        original_library_id: &str,
+    ) -> Result<bool, sqlx::Error> {
+        let original_library_id = normalize_library_id(original_library_id);
+        let result = sqlx::query(
+            "DELETE FROM library_group_members \
+             WHERE group_virtual_id = ? AND server_id = ? AND original_library_id = ?",
+        )
+        .bind(group_virtual_id)
+        .bind(server_id.as_i64())
+        .bind(&original_library_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn list_members(
+        &self,
+        group_virtual_id: &str,
+    ) -> Result<Vec<LibraryGroupMemberRecord>, sqlx::Error> {
+        let rows: Vec<(String, i64, String, String)> = sqlx::query_as(
+            "SELECT group_virtual_id, server_id, original_library_id, library_name \
+             FROM library_group_members WHERE group_virtual_id = ? \
+             ORDER BY library_name",
+        )
+        .bind(group_virtual_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(
+                |(group_virtual_id, server_id, original_library_id, library_name)| {
+                    LibraryGroupMemberRecord {
+                        group_virtual_id,
+                        server_id: ServerId::new(server_id),
+                        original_library_id,
+                        library_name,
+                    }
+                },
+            )
+            .collect())
+    }
+
+    pub async fn get_assignments(
+        &self,
+    ) -> Result<HashMap<(ServerId, String), LibraryAssignment>, sqlx::Error> {
+        let rows: Vec<(i64, String, String, String)> = sqlx::query_as(
+            "SELECT m.server_id, m.original_library_id, g.virtual_id, g.name \
+             FROM library_group_members m \
+             JOIN library_groups g ON g.virtual_id = m.group_virtual_id",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(server_id, original_library_id, group_virtual_id, group_name)| {
+                (
+                    (ServerId::new(server_id), original_library_id),
+                    LibraryAssignment {
+                        group_virtual_id,
+                        group_name,
+                    },
+                )
+            })
+            .collect())
+    }
+
+    pub async fn resolve(
+        &self,
+        state: &AppState,
+        virtual_id: &str,
+    ) -> Result<Option<(LibraryGroup, Vec<MergedLibraryMember>)>, sqlx::Error> {
+        let virtual_id = normalize_library_id(virtual_id);
+        let group = match self.get_group(&virtual_id).await? {
+            Some(group) => group,
+            None => return Ok(None),
+        };
+
+        let records = self.list_members(&group.virtual_id).await?;
+        if records.is_empty() {
+            return Ok(Some((group, Vec::new())));
+        }
+
+        let mut members = Vec::new();
+        for record in records {
+            let server = match state
+                .server_storage
+                .get_server_by_id(record.server_id)
+                .await
+            {
+                Ok(Some(server)) => server,
+                Ok(None) => continue,
+                Err(e) => return Err(e),
+            };
+
+            let mapping = state
+                .media_storage
+                .get_or_create_media_mapping(&record.original_library_id, &server)
+                .await?;
+
+            members.push(MergedLibraryMember {
+                server_url: server.url.to_string(),
+                virtual_library_id: mapping.virtual_media_id,
+            });
+        }
+
+        Ok(Some((group, members)))
+    }
+
+    pub async fn get_group(&self, virtual_id: &str) -> Result<Option<LibraryGroup>, sqlx::Error> {
+        let row: Option<(String, String, i32, String, Option<i64>)> = sqlx::query_as(
+            "SELECT virtual_id, name, sort_order, duplicate_policy, preferred_server_id \
+             FROM library_groups WHERE virtual_id = ?",
+        )
+        .bind(virtual_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(
+            |(virtual_id, name, sort_order, duplicate_policy, preferred_server_id)| LibraryGroup {
+                virtual_id,
+                name,
+                sort_order,
+                duplicate_policy: duplicate_policy
+                    .parse()
+                    .unwrap_or(crate::duplicate_policy::DuplicatePolicy::ShowAll),
+                preferred_server_id: preferred_server_id.map(ServerId::new),
+            },
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::MIGRATOR;
+
+    async fn test_pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn create_group_and_assign_member() {
+        let pool = test_pool().await;
+        let service = LibraryGroupService::new(pool.clone());
+
+        sqlx::query(
+            "INSERT INTO servers (id, name, url, priority, media_streaming_mode, created_at, updated_at) \
+             VALUES (1, 'Server A', 'http://a:8096', 100, 'Redirect', datetime('now'), datetime('now'))",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let group = service.create_group("Anime").await.unwrap();
+        service
+            .add_member(
+                &group.virtual_id,
+                ServerId::new(1),
+                "abc-def-1234-5678-901234567890",
+                "Anime",
+            )
+            .await
+            .unwrap();
+
+        let assignments = service.get_assignments().await.unwrap();
+        assert_eq!(assignments.len(), 1);
+        assert_eq!(
+            assignments
+                .values()
+                .next()
+                .map(|a| a.group_name.as_str()),
+            Some("Anime")
+        );
+    }
+}

--- a/crates/jellyswarrm-proxy/src/library_group_service.rs
+++ b/crates/jellyswarrm-proxy/src/library_group_service.rs
@@ -292,11 +292,12 @@ impl LibraryGroupService {
     }
 
     pub async fn get_group(&self, virtual_id: &str) -> Result<Option<LibraryGroup>, sqlx::Error> {
+        let virtual_id = normalize_library_id(virtual_id);
         let row: Option<(String, String, i32, String, Option<i64>)> = sqlx::query_as(
             "SELECT virtual_id, name, sort_order, duplicate_policy, preferred_server_id \
              FROM library_groups WHERE virtual_id = ?",
         )
-        .bind(virtual_id)
+        .bind(&virtual_id)
         .fetch_optional(&self.pool)
         .await?;
 

--- a/crates/jellyswarrm-proxy/src/main.rs
+++ b/crates/jellyswarrm-proxy/src/main.rs
@@ -27,11 +27,13 @@ use axum_login::{
 };
 
 mod config;
+mod duplicate_policy;
 mod encryption;
 mod extractors;
 mod federated_users;
 mod handlers;
 mod legacy_server_identity;
+mod library_group_service;
 mod media_storage_service;
 mod merged_library_service;
 mod models;
@@ -49,6 +51,7 @@ mod user_authorization_service;
 use federated_users::FederatedUserService;
 use handlers::syncplay::SyncPlayService;
 use legacy_server_identity::canonicalize_legacy_server_identity;
+use library_group_service::LibraryGroupService;
 use media_storage_service::MediaStorageService;
 use merged_library_service::MergedLibraryService;
 use server_storage::{Server, ServerStorageService};
@@ -87,6 +90,7 @@ pub struct AppState {
     pub server_storage: Arc<ServerStorageService>,
     pub media_storage: Arc<MediaStorageService>,
     pub merged_library_service: Arc<MergedLibraryService>,
+    pub library_group_service: Arc<LibraryGroupService>,
     pub play_sessions: Arc<SessionStorage>,
     pub config: Arc<tokio::sync::RwLock<AppConfig>>,
     pub processors: Arc<ProxyProcessors>,
@@ -119,6 +123,7 @@ impl AppState {
             server_storage: data_context.server_storage,
             media_storage: data_context.media_storage,
             merged_library_service: data_context.merged_library_service,
+            library_group_service: data_context.library_group_service,
             play_sessions: data_context.play_sessions,
             config: data_context.config,
             processors: Arc::new(proxy_processors),
@@ -205,6 +210,7 @@ pub struct DataContext {
     pub server_storage: Arc<ServerStorageService>,
     pub media_storage: Arc<MediaStorageService>,
     pub merged_library_service: Arc<MergedLibraryService>,
+    pub library_group_service: Arc<LibraryGroupService>,
     pub play_sessions: Arc<SessionStorage>,
     pub config: Arc<tokio::sync::RwLock<AppConfig>>,
 }
@@ -373,6 +379,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let media_storage = MediaStorageService::new(pool.clone());
 
     let merged_library_service = MergedLibraryService::new(pool.clone());
+    let library_group_service = LibraryGroupService::new(pool.clone());
 
     if !loaded_config.preconfigured_servers.is_empty() {
         info!(
@@ -429,6 +436,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         server_storage: Arc::new(server_storage.clone()),
         media_storage: Arc::new(media_storage.clone()),
         merged_library_service: Arc::new(merged_library_service),
+        library_group_service: Arc::new(library_group_service),
         play_sessions: Arc::new(SessionStorage::new()),
         config: Arc::new(tokio::sync::RwLock::new(loaded_config.clone())),
     };

--- a/crates/jellyswarrm-proxy/src/processors/request_processor.rs
+++ b/crates/jellyswarrm-proxy/src/processors/request_processor.rs
@@ -112,6 +112,7 @@ mod tests {
         config::{AppConfig, MediaStreamingMode, MIGRATOR},
         media_storage_service::MediaStorageService,
         merged_library_service::MergedLibraryService,
+        library_group_service::LibraryGroupService,
         processors::process_json,
         server_id::ServerId,
         server_storage::ServerStorageService,
@@ -128,7 +129,8 @@ mod tests {
             user_authorization: Arc::new(UserAuthorizationService::new(pool.clone())),
             server_storage: Arc::new(ServerStorageService::new(pool.clone())),
             media_storage: Arc::new(MediaStorageService::new(pool.clone())),
-            merged_library_service: Arc::new(MergedLibraryService::new(pool)),
+            merged_library_service: Arc::new(MergedLibraryService::new(pool.clone())),
+            library_group_service: Arc::new(LibraryGroupService::new(pool)),
             play_sessions: Arc::new(SessionStorage::new()),
             config: Arc::new(tokio::sync::RwLock::new(AppConfig::default())),
         }

--- a/crates/jellyswarrm-proxy/src/processors/url_processor.rs
+++ b/crates/jellyswarrm-proxy/src/processors/url_processor.rs
@@ -292,6 +292,10 @@ impl UrlProcessor {
             return Some(mapping);
         }
 
+        if let Some(mapping) = self.library_group_member_mapping(virtual_media_id).await {
+            return Some(mapping);
+        }
+
         let member_virtual_id = self
             .data_context
             .merged_library_service
@@ -305,6 +309,30 @@ impl UrlProcessor {
             .get_media_mapping_by_virtual(&member_virtual_id)
             .await
             .unwrap_or_default()
+    }
+
+    async fn library_group_member_mapping(&self, group_virtual_id: &str) -> Option<MediaMapping> {
+        let group = self
+            .data_context
+            .library_group_service
+            .get_group(group_virtual_id)
+            .await
+            .ok()??;
+
+        let members = self
+            .data_context
+            .library_group_service
+            .list_members(&group.virtual_id)
+            .await
+            .ok()?;
+
+        let first = members.first()?;
+
+        self.data_context
+            .media_storage
+            .get_media_mapping_by_original(&first.original_library_id, first.server_id)
+            .await
+            .ok()?
     }
 
     async fn server_from_path_media_ids(&self, url: &url::Url) -> Result<Option<Server>> {

--- a/crates/jellyswarrm-proxy/src/ui/admin/libraries.rs
+++ b/crates/jellyswarrm-proxy/src/ui/admin/libraries.rs
@@ -1,0 +1,584 @@
+use askama::Template;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::{Html, IntoResponse, Response},
+    Form,
+};
+use jellyfin_api::JellyfinClient;
+use serde::Deserialize;
+use tracing::{error, info};
+
+use crate::{
+    config::CLIENT_INFO,
+    duplicate_policy::DuplicatePolicy,
+    encryption::{decrypt_password, HashedPassword},
+    library_group_service::{normalize_library_id, LibraryGroupMemberRecord},
+    server_id::ServerId,
+    AppState,
+};
+
+#[derive(Template)]
+#[template(path = "admin/libraries.html")]
+pub struct LibrariesPageTemplate {
+    pub merge_libraries: bool,
+    pub ui_route: String,
+}
+
+#[derive(Template)]
+#[template(path = "admin/library_groups_list.html")]
+pub struct LibraryGroupsListTemplate {
+    pub groups: Vec<LibraryGroupView>,
+    pub discovered_libraries: Vec<DiscoveredLibraryView>,
+    pub servers: Vec<ServerOptionView>,
+    pub duplicate_policies: Vec<DuplicatePolicyOptionView>,
+    pub ui_route: String,
+}
+
+pub struct ServerOptionView {
+    pub id: i64,
+    pub name: String,
+}
+
+pub struct DuplicatePolicyOptionView {
+    pub value: String,
+    pub label: String,
+}
+
+pub struct LibraryGroupView {
+    pub virtual_id: String,
+    pub name: String,
+    pub duplicate_policy: String,
+    pub preferred_server_id: Option<i64>,
+    pub members: Vec<LibraryGroupMemberView>,
+}
+
+pub struct LibraryGroupMemberView {
+    pub server_id: i64,
+    pub server_name: String,
+    pub original_library_id: String,
+    pub library_name: String,
+}
+
+pub struct DiscoveredLibraryView {
+    pub server_id: i64,
+    pub server_name: String,
+    pub library_id: String,
+    pub library_name: String,
+    pub collection_type: String,
+    pub assigned_group: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct CreateGroupForm {
+    pub name: String,
+}
+
+#[derive(Deserialize)]
+pub struct AssignLibraryForm {
+    pub group_virtual_id: String,
+    pub server_id: i64,
+    pub library_id: String,
+    pub library_name: String,
+}
+
+#[derive(Deserialize)]
+pub struct RemoveMemberForm {
+    pub server_id: i64,
+    pub library_id: String,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateGroupPolicyForm {
+    pub duplicate_policy: String,
+    pub preferred_server_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct RenameGroupForm {
+    pub name: String,
+}
+
+pub async fn libraries_page(State(state): State<AppState>) -> impl IntoResponse {
+    let merge_libraries = state.merge_libraries_enabled().await;
+    let template = LibrariesPageTemplate {
+        merge_libraries,
+        ui_route: state.get_ui_route().await,
+    };
+    match template.render() {
+        Ok(html) => Html(html).into_response(),
+        Err(e) => {
+            error!("Failed to render libraries page: {}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Template error").into_response()
+        }
+    }
+}
+
+pub async fn library_groups_list(State(state): State<AppState>) -> impl IntoResponse {
+    match render_library_groups_list(&state).await {
+        Ok(html) => Html(html).into_response(),
+        Err(message) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Html(format!("<div class=\"alert alert-error\">{message}</div>")),
+        )
+            .into_response(),
+    }
+}
+
+async fn render_library_groups_list(state: &AppState) -> Result<String, String> {
+    if state.merge_libraries_enabled().await {
+        return Ok(
+            "<article><p>Disable <strong>Merge Libraries Across Servers</strong> in Settings to use custom library groups.</p></article>".to_string(),
+        );
+    }
+
+    let groups = state
+        .library_group_service
+        .list_groups()
+        .await
+        .map_err(|e| format!("Failed to load groups: {e}"))?;
+
+    let mut group_views = Vec::new();
+    for group in groups {
+        let members = state
+            .library_group_service
+            .list_members(&group.virtual_id)
+            .await
+            .map_err(|e| format!("Failed to load group members: {e}"))?;
+
+        let member_views = members
+            .into_iter()
+            .map(|member: LibraryGroupMemberRecord| LibraryGroupMemberView {
+                server_id: member.server_id.as_i64(),
+                server_name: String::new(),
+                original_library_id: member.original_library_id,
+                library_name: member.library_name,
+            })
+            .collect::<Vec<_>>();
+
+        group_views.push(LibraryGroupView {
+            virtual_id: group.virtual_id,
+            name: group.name,
+            duplicate_policy: group.duplicate_policy.to_string(),
+            preferred_server_id: group.preferred_server_id.map(|id| id.as_i64()),
+            members: member_views,
+        });
+    }
+
+    let servers = state
+        .server_storage
+        .list_servers()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|server| ServerOptionView {
+            id: server.id.as_i64(),
+            name: server.name,
+        })
+        .collect::<Vec<_>>();
+
+    let duplicate_policies = [
+        DuplicatePolicy::ShowAll,
+        DuplicatePolicy::LargestSize,
+        DuplicatePolicy::SmallestSize,
+        DuplicatePolicy::BestQuality,
+        DuplicatePolicy::LowestQuality,
+        DuplicatePolicy::PreferServer,
+        DuplicatePolicy::ServerPriority,
+    ]
+    .into_iter()
+    .map(|policy| DuplicatePolicyOptionView {
+        value: policy.to_string(),
+        label: policy.label().to_string(),
+    })
+    .collect();
+
+    let discovered = discover_libraries(state).await;
+    let assignments = state
+        .library_group_service
+        .get_assignments()
+        .await
+        .unwrap_or_default();
+
+    for group in &mut group_views {
+        for member in &mut group.members {
+            if let Ok(Some(server)) = state
+                .server_storage
+                .get_server_by_id(ServerId::new(member.server_id))
+                .await
+            {
+                member.server_name = server.name;
+            }
+        }
+    }
+
+    let discovered_views = discovered
+        .into_iter()
+        .map(|library| {
+            let assigned_group = assignments
+                .get(&(library.server_id, normalize_library_id(&library.library_id)))
+                .map(|assignment| assignment.group_name.clone());
+
+            DiscoveredLibraryView {
+                server_id: library.server_id.as_i64(),
+                server_name: library.server_name,
+                library_id: library.library_id,
+                library_name: library.library_name,
+                collection_type: library.collection_type,
+                assigned_group,
+            }
+        })
+        .collect();
+
+    let template = LibraryGroupsListTemplate {
+        groups: group_views,
+        discovered_libraries: discovered_views,
+        servers,
+        duplicate_policies,
+        ui_route: state.get_ui_route().await,
+    };
+
+    template.render().map_err(|e| format!("Template error: {e}"))
+}
+
+struct DiscoveredLibrary {
+    server_id: ServerId,
+    server_name: String,
+    library_id: String,
+    library_name: String,
+    collection_type: String,
+}
+
+async fn discover_libraries(state: &AppState) -> Vec<DiscoveredLibrary> {
+    let servers = match state.server_storage.list_servers().await {
+        Ok(servers) => servers,
+        Err(e) => {
+            error!("Failed to list servers for library discovery: {}", e);
+            return Vec::new();
+        }
+    };
+
+    let config = state.config.read().await;
+    let admin_password: HashedPassword = config.password.clone().into();
+    drop(config);
+
+    let mut discovered = Vec::new();
+
+    for server in servers {
+        let Some(admin) = state
+            .server_storage
+            .get_server_admin(server.id)
+            .await
+            .unwrap_or(None)
+        else {
+            continue;
+        };
+
+        let decrypted_password = match decrypt_password(&admin.password, &admin_password) {
+            Ok(password) => password,
+            Err(e) => {
+                error!(
+                    "Failed to decrypt admin password for server {}: {}",
+                    server.name, e
+                );
+                continue;
+            }
+        };
+
+        let client = match JellyfinClient::new(server.url.as_str(), CLIENT_INFO.clone()) {
+            Ok(client) => client,
+            Err(e) => {
+                error!("Failed to create Jellyfin client for {}: {}", server.name, e);
+                continue;
+            }
+        };
+
+        if client
+            .authenticate_by_name(&admin.username, decrypted_password.as_str())
+            .await
+            .is_err()
+        {
+            error!("Failed to authenticate as admin on server {}", server.name);
+            continue;
+        }
+
+        let folders = match client.get_media_folders(None).await {
+            Ok(folders) => folders,
+            Err(e) => {
+                error!("Failed to list libraries on server {}: {}", server.name, e);
+                continue;
+            }
+        };
+
+        for folder in folders {
+            if folder
+                .collection_type
+                .as_deref()
+                .is_some_and(|collection_type| collection_type.eq_ignore_ascii_case("livetv"))
+            {
+                continue;
+            }
+
+            discovered.push(DiscoveredLibrary {
+                server_id: server.id,
+                server_name: server.name.clone(),
+                library_id: folder.id,
+                library_name: folder.name,
+                collection_type: folder.collection_type.unwrap_or_default(),
+            });
+        }
+    }
+
+    discovered.sort_by(|left, right| {
+        left.server_name
+            .cmp(&right.server_name)
+            .then_with(|| left.library_name.cmp(&right.library_name))
+    });
+
+    discovered
+}
+
+fn library_groups_blocked_response() -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Html("<div class=\"alert alert-error\">Disable <strong>Merge Libraries Across Servers</strong> in Settings to use custom library groups.</div>"),
+    )
+        .into_response()
+}
+
+pub async fn create_group(
+    State(state): State<AppState>,
+    Form(form): Form<CreateGroupForm>,
+) -> Response {
+    if state.merge_libraries_enabled().await {
+        return library_groups_blocked_response();
+    }
+
+    if form.name.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Html("<div class=\"alert alert-error\">Group name is required</div>"),
+        )
+            .into_response();
+    }
+
+    match state
+        .library_group_service
+        .create_group(form.name.trim())
+        .await
+    {
+        Ok(group) => {
+            info!("Created library group: {}", group.name);
+            match render_library_groups_list(&state).await {
+                Ok(html) => Html(html).into_response(),
+                Err(message) => (StatusCode::INTERNAL_SERVER_ERROR, message).into_response(),
+            }
+        }
+        Err(e) => {
+            error!("Failed to create library group: {}", e);
+            let message = if e.to_string().contains("UNIQUE constraint failed") {
+                "A group with that name already exists"
+            } else {
+                "Failed to create library group"
+            };
+            (
+                StatusCode::BAD_REQUEST,
+                Html(format!("<div class=\"alert alert-error\">{message}</div>")),
+            )
+                .into_response()
+        }
+    }
+}
+
+pub async fn delete_group(
+    State(state): State<AppState>,
+    Path(virtual_id): Path<String>,
+) -> Response {
+    if state.merge_libraries_enabled().await {
+        return library_groups_blocked_response();
+    }
+
+    match state.library_group_service.delete_group(&virtual_id).await {
+        Ok(true) => match render_library_groups_list(&state).await {
+            Ok(html) => Html(html).into_response(),
+            Err(message) => (StatusCode::INTERNAL_SERVER_ERROR, message).into_response(),
+        },
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Html("<div class=\"alert alert-error\">Group not found</div>"),
+        )
+            .into_response(),
+        Err(e) => {
+            error!("Failed to delete library group: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Html("<div class=\"alert alert-error\">Failed to delete group</div>"),
+            )
+                .into_response()
+        }
+    }
+}
+
+pub async fn assign_library(
+    State(state): State<AppState>,
+    Form(form): Form<AssignLibraryForm>,
+) -> Response {
+    if state.merge_libraries_enabled().await {
+        return library_groups_blocked_response();
+    }
+
+    let server_id = ServerId::new(form.server_id);
+
+    match state
+        .library_group_service
+        .add_member(
+            &form.group_virtual_id,
+            server_id,
+            &form.library_id,
+            &form.library_name,
+        )
+        .await
+    {
+        Ok(()) => match render_library_groups_list(&state).await {
+            Ok(html) => Html(html).into_response(),
+            Err(message) => (StatusCode::INTERNAL_SERVER_ERROR, message).into_response(),
+        },
+        Err(e) => {
+            error!("Failed to assign library to group: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Html("<div class=\"alert alert-error\">Failed to assign library</div>"),
+            )
+                .into_response()
+        }
+    }
+}
+
+pub async fn update_group_policy(
+    State(state): State<AppState>,
+    Path(virtual_id): Path<String>,
+    Form(form): Form<UpdateGroupPolicyForm>,
+) -> Response {
+    if state.merge_libraries_enabled().await {
+        return library_groups_blocked_response();
+    }
+
+    let policy = match form.duplicate_policy.parse::<DuplicatePolicy>() {
+        Ok(policy) => policy,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Html("<div class=\"alert alert-error\">Invalid duplicate policy</div>"),
+            )
+                .into_response();
+        }
+    };
+
+    let preferred_server_id = form
+        .preferred_server_id
+        .filter(|value| !value.trim().is_empty())
+        .and_then(|value| value.parse::<i64>().ok())
+        .map(ServerId::new);
+
+    match state
+        .library_group_service
+        .update_group_policy(&virtual_id, policy, preferred_server_id)
+        .await
+    {
+        Ok(true) => match render_library_groups_list(&state).await {
+            Ok(html) => Html(html).into_response(),
+            Err(message) => (StatusCode::INTERNAL_SERVER_ERROR, message).into_response(),
+        },
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Html("<div class=\"alert alert-error\">Group not found</div>"),
+        )
+            .into_response(),
+        Err(e) => {
+            error!("Failed to update library group policy: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Html("<div class=\"alert alert-error\">Failed to update duplicate policy</div>"),
+            )
+                .into_response()
+        }
+    }
+}
+
+pub async fn rename_group(
+    State(state): State<AppState>,
+    Path(virtual_id): Path<String>,
+    Form(form): Form<RenameGroupForm>,
+) -> Response {
+    if state.merge_libraries_enabled().await {
+        return library_groups_blocked_response();
+    }
+
+    if form.name.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Html("<div class=\"alert alert-error\">Display name is required</div>"),
+        )
+            .into_response();
+    }
+
+    match state
+        .library_group_service
+        .rename_group(&virtual_id, form.name.trim())
+        .await
+    {
+        Ok(true) => match render_library_groups_list(&state).await {
+            Ok(html) => Html(html).into_response(),
+            Err(message) => (StatusCode::INTERNAL_SERVER_ERROR, message).into_response(),
+        },
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Html("<div class=\"alert alert-error\">Group not found</div>"),
+        )
+            .into_response(),
+        Err(e) => {
+            error!("Failed to rename library group: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Html("<div class=\"alert alert-error\">Failed to rename group</div>"),
+            )
+                .into_response()
+        }
+    }
+}
+
+pub async fn remove_member(
+    State(state): State<AppState>,
+    Path(group_virtual_id): Path<String>,
+    Form(form): Form<RemoveMemberForm>,
+) -> Response {
+    if state.merge_libraries_enabled().await {
+        return library_groups_blocked_response();
+    }
+
+    let server_id = ServerId::new(form.server_id);
+
+    match state
+        .library_group_service
+        .remove_member(&group_virtual_id, server_id, &form.library_id)
+        .await
+    {
+        Ok(true) => match render_library_groups_list(&state).await {
+            Ok(html) => Html(html).into_response(),
+            Err(message) => (StatusCode::INTERNAL_SERVER_ERROR, message).into_response(),
+        },
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Html("<div class=\"alert alert-error\">Library assignment not found</div>"),
+        )
+            .into_response(),
+        Err(e) => {
+            error!("Failed to remove library from group: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Html("<div class=\"alert alert-error\">Failed to remove library</div>"),
+            )
+                .into_response()
+        }
+    }
+}

--- a/crates/jellyswarrm-proxy/src/ui/admin/mod.rs
+++ b/crates/jellyswarrm-proxy/src/ui/admin/mod.rs
@@ -1,3 +1,4 @@
+pub mod libraries;
 pub mod servers;
 pub mod settings;
 pub mod users;

--- a/crates/jellyswarrm-proxy/src/ui/mod.rs
+++ b/crates/jellyswarrm-proxy/src/ui/mod.rs
@@ -132,6 +132,26 @@ pub fn ui_routes() -> axum::Router<AppState> {
             "/servers/{id}/admin",
             axum::routing::delete(admin::servers::delete_server_admin),
         )
+        .route("/libraries", get(admin::libraries::libraries_page))
+        .route("/libraries/list", get(admin::libraries::library_groups_list))
+        .route("/libraries/groups", post(admin::libraries::create_group))
+        .route(
+            "/libraries/groups/{virtual_id}",
+            axum::routing::delete(admin::libraries::delete_group),
+        )
+        .route("/libraries/assign", post(admin::libraries::assign_library))
+        .route(
+            "/libraries/groups/{group_virtual_id}/remove",
+            post(admin::libraries::remove_member),
+        )
+        .route(
+            "/libraries/groups/{virtual_id}/policy",
+            post(admin::libraries::update_group_policy),
+        )
+        .route(
+            "/libraries/groups/{virtual_id}/rename",
+            post(admin::libraries::rename_group),
+        )
         // Settings
         .route("/settings", get(admin::settings::settings_page))
         .route("/settings/form", get(admin::settings::settings_form))

--- a/crates/jellyswarrm-proxy/src/ui/resources/custom.css
+++ b/crates/jellyswarrm-proxy/src/ui/resources/custom.css
@@ -101,6 +101,51 @@
   margin-bottom: 0.5rem;
 }
 
+.library-group-card {
+  margin-bottom: 1.25rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--pico-muted-border-color);
+}
+
+.library-group-card:last-of-type {
+  border-bottom: none;
+}
+
+.library-group-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: end;
+  margin-bottom: 1rem;
+}
+
+.library-group-name-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: end;
+  margin: 0;
+}
+
+.library-group-policy-form {
+  margin: 0 0 1rem;
+}
+
+.library-group-policy-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
+  gap: 1rem;
+  align-items: end;
+}
+
+@media (max-width: 900px) {
+  .library-group-header,
+  .library-group-name-form,
+  .library-group-policy-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
 .server-form-grid {
   display: grid;
   grid-template-columns: minmax(10rem, 1fr) minmax(13rem, 1.35fr) minmax(7.5rem, 0.7fr) minmax(12rem, 1fr) auto;

--- a/crates/jellyswarrm-proxy/src/ui/templates/admin/index.html
+++ b/crates/jellyswarrm-proxy/src/ui/templates/admin/index.html
@@ -16,6 +16,12 @@
     </a>
 </li>
 <li>
+    <a href="#" hx-get="/{{ ui_route }}/libraries" hx-target="#main-content" class="nav-link">
+        <i class="fas fa-folder-tree" style="margin-right: 0.25rem;"></i>
+        Libraries
+    </a>
+</li>
+<li>
     <a href="#" hx-get="/{{ ui_route }}/settings" hx-target="#main-content" class="nav-link">
         <i class="fas fa-cog" style="margin-right: 0.25rem;"></i>
         Settings

--- a/crates/jellyswarrm-proxy/src/ui/templates/admin/libraries.html
+++ b/crates/jellyswarrm-proxy/src/ui/templates/admin/libraries.html
@@ -1,0 +1,36 @@
+<header>
+    <h1>Library Groups</h1>
+    <h3>Combine libraries from multiple servers into one folder in Jellyswarrm.</h3>
+</header>
+
+{% if merge_libraries %}
+<article>
+    <header><h4>Auto-merge is enabled</h4></header>
+    <p>Libraries with the same name and type are merged automatically via <strong>Merge Libraries Across Servers</strong> in Settings.</p>
+    <p>Disable that setting to configure custom library groups here instead.</p>
+</article>
+{% else %}
+
+<section aria-labelledby="create-group-heading">
+    <h2 id="create-group-heading" class="section-heading-tight">Create Group</h2>
+    <form hx-post="/{{ ui_route }}/libraries/groups" hx-target="#library-groups-list" hx-swap="innerHTML" hx-disabled-elt="this" hx-on::after-request="if(event.detail.successful) this.reset()">
+        <div class="server-form-grid">
+            <label class="form-field">
+                <span class="field-label">Group Name</span>
+                <input type="text" name="name" placeholder="e.g. Anime" autocomplete="off" required>
+            </label>
+            <div class="server-form-submit">
+                <span class="field-label field-label-placeholder" aria-hidden="true">Create</span>
+                <button type="submit" class="server-form-button">Create Group</button>
+            </div>
+        </div>
+    </form>
+</section>
+
+<hr />
+
+<section id="library-groups-list" hx-get="/{{ ui_route }}/libraries/list" hx-trigger="load">
+    <p>Loading library groups...</p>
+</section>
+
+{% endif %}

--- a/crates/jellyswarrm-proxy/src/ui/templates/admin/library_groups_list.html
+++ b/crates/jellyswarrm-proxy/src/ui/templates/admin/library_groups_list.html
@@ -1,0 +1,137 @@
+{% if groups.is_empty() && discovered_libraries.is_empty() %}
+<article>
+    <header><h4>No libraries discovered</h4></header>
+    <p>Add Jellyfin servers with federation admin credentials configured, then refresh this page.</p>
+</article>
+{% else %}
+
+{% if !groups.is_empty() %}
+<h2 class="section-heading-tight">Configured Groups</h2>
+{% for group in groups %}
+<article class="library-group-card">
+    <div class="library-group-header">
+        <form class="library-group-name-form" hx-post="/{{ ui_route }}/libraries/groups/{{ group.virtual_id }}/rename" hx-target="#library-groups-list" hx-swap="innerHTML">
+            <label class="form-field">
+                <span class="field-label">Shown name</span>
+                <input type="text" name="name" value="{{ group.name }}" autocomplete="off" required>
+            </label>
+            <button type="submit" class="outline">Save Name</button>
+        </form>
+        <button type="button" class="icon-btn danger"
+                hx-delete="/{{ ui_route }}/libraries/groups/{{ group.virtual_id }}"
+                hx-target="#library-groups-list" hx-swap="innerHTML"
+                hx-confirm="Delete group '{{ group.name }}'?"
+                title="Delete group">
+            <i class="fas fa-trash" aria-hidden="true"></i>
+        </button>
+    </div>
+    <form class="library-group-policy-form" hx-post="/{{ ui_route }}/libraries/groups/{{ group.virtual_id }}/policy" hx-target="#library-groups-list" hx-swap="innerHTML">
+        <div class="library-group-policy-grid">
+            <label class="form-field">
+                <span class="field-label">Duplicate handling</span>
+                <select name="duplicate_policy" required>
+                    {% for policy in duplicate_policies %}
+                    <option value="{{ policy.value }}" {% if group.duplicate_policy == policy.value %}selected{% endif %}>{{ policy.label }}</option>
+                    {% endfor %}
+                </select>
+            </label>
+            <label class="form-field">
+                <span class="field-label">Preferred server</span>
+                <select name="preferred_server_id">
+                    <option value="">Auto / use server priority</option>
+                    {% for server in servers %}
+                    <option value="{{ server.id }}" {% match group.preferred_server_id %}{% when Some with (preferred) %}{% if *preferred == server.id %}selected{% endif %}{% when None %}{% endmatch %}>{{ server.name }}</option>
+                    {% endfor %}
+                </select>
+            </label>
+            <button type="submit" class="secondary">Save Policy</button>
+        </div>
+    </form>
+    {% if group.members.is_empty() %}
+    <p>No libraries assigned yet.</p>
+    {% else %}
+    <table aria-label="Libraries in {{ group.name }}">
+        <thead>
+            <tr>
+                <th>Server</th>
+                <th>Library</th>
+                <th style="text-align:center;">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for member in group.members %}
+            <tr>
+                <td>{{ member.server_name }}</td>
+                <td>{{ member.library_name }}</td>
+                <td style="text-align:center;">
+                    <button type="button" class="icon-btn danger"
+                            hx-post="/{{ ui_route }}/libraries/groups/{{ group.virtual_id }}/remove"
+                            hx-target="#library-groups-list" hx-swap="innerHTML"
+                            hx-vals='{"server_id":"{{ member.server_id }}","library_id":"{{ member.original_library_id }}"}'
+                            title="Remove from group">
+                        <i class="fas fa-unlink" aria-hidden="true"></i>
+                    </button>
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
+</article>
+{% endfor %}
+<hr />
+{% endif %}
+
+<h2 class="section-heading-tight">Available Libraries</h2>
+<p>Assign libraries from your connected servers into a group. Each library can belong to one group.</p>
+
+{% if discovered_libraries.is_empty() %}
+<p>No libraries found. Configure federation admin credentials on your servers first.</p>
+{% else %}
+<table aria-label="Available libraries">
+    <thead>
+        <tr>
+            <th>Server</th>
+            <th>Library</th>
+            <th>Type</th>
+            <th>Assigned To</th>
+            <th>Add To Group</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for library in discovered_libraries %}
+        <tr>
+            <td>{{ library.server_name }}</td>
+            <td>{{ library.library_name }}</td>
+            <td>{{ library.collection_type }}</td>
+            <td>
+                {% if let Some(group_name) = library.assigned_group %}
+                    <span class="badge success">{{ group_name }}</span>
+                {% else %}
+                    <span class="badge secondary">Unassigned</span>
+                {% endif %}
+            </td>
+            <td>
+                {% if groups.is_empty() %}
+                    <small class="secondary">Create a group first</small>
+                {% else %}
+                <form hx-post="/{{ ui_route }}/libraries/assign" hx-target="#library-groups-list" hx-swap="innerHTML" style="display:flex; gap:0.5rem; align-items:center; margin:0;">
+                    <input type="hidden" name="server_id" value="{{ library.server_id }}">
+                    <input type="hidden" name="library_id" value="{{ library.library_id }}">
+                    <input type="hidden" name="library_name" value="{{ library.library_name }}">
+                    <select name="group_virtual_id" required style="margin-bottom:0; min-width: 10rem;">
+                        {% for group in groups %}
+                        <option value="{{ group.virtual_id }}">{{ group.name }}</option>
+                        {% endfor %}
+                    </select>
+                    <button type="submit" class="outline" style="margin-bottom:0; white-space:nowrap;">Assign</button>
+                </form>
+                {% endif %}
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endif %}
+
+{% endif %}


### PR DESCRIPTION
I made a fork that I believe is a good way to map the libraries. I made it so that when the content is not auto merged, you can choose folders to map to so you can have multiple folders that are Movies that do not pool. For example a separate Movies folder for Anime Movies vs Non Anime Movies. This should also address #60 