### PR TITLE
Federate /UserItems/Resume (Continue Watching for modern SDK clients)

### DIFF
--- a/crates/jellyswarrm-proxy/src/main.rs
+++ b/crates/jellyswarrm-proxy/src/main.rs
@@ -571,6 +571,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "/UserViews",
                 get(handlers::federated::get_items_from_all_servers),
             )
+            // Newer Jellyfin SDKs (e.g. jellyfin-sdk-kotlin, used by the Android TV
+            // client) request Continue Watching from /UserItems/Resume instead of the
+            // legacy /Users/{userId}/Items/Resume. Federate it the same way so resume
+            // items merge across all servers; otherwise it falls through to the
+            // single-server proxy fallback and only one backend's items appear.
+            .route(
+                "/UserItems/Resume",
+                get(handlers::federated::get_items_from_all_servers),
+            )
             // System info routes
             .nest(
                 "/System",


### PR DESCRIPTION
### Problem
On a Jellyswarrm setup, "Continue Watching" only shows items from a single backing server for clients built on a current Jellyfin SDK (Android TV / the official jellyfin-sdk-kotlin, current jellyfin-web, etc.). Older clients on the legacy api-client show the full merged list.

### Cause
Modern SDKs request resume items from `GET /UserItems/Resume`; the legacy api-client uses `GET /Users/{userId}/Items/Resume`. On a real Jellyfin server these are two routes onto the *same* controller action — the legacy one is just an `[Obsolete]` delegate to the new one, so results are identical:

```csharp
// jellyfin/jellyfin — Jellyfin.Api/Controllers/ItemsController.cs (v10.11.11)

// New, canonical route (L824)
[HttpGet("UserItems/Resume")]
[ProducesResponseType(StatusCodes.Status200OK)]
public ActionResult<QueryResult<BaseItemDto>> GetResumeItems(
    [FromQuery] Guid? userId, /* ... */) { /* real implementation */ }

// Legacy route (L924) — same handler, marked obsolete, just forwards:
[HttpGet("Users/{userId}/Items/Resume")]
[Obsolete("Kept for backwards compatibility")]
[ApiExplorerSettings(IgnoreApi = true)]
[ProducesResponseType(StatusCodes.Status200OK)]
public ActionResult<QueryResult<BaseItemDto>> GetResumeItemsLegacy(
    [FromRoute, Required] Guid userId, /* ...same params... */)
    => GetResumeItems(userId, startIndex, limit, /* ...same args... */);
```
- https://github.com/jellyfin/jellyfin/blob/v10.11.11/Jellyfin.Api/Controllers/ItemsController.cs#L824
- https://github.com/jellyfin/jellyfin/blob/v10.11.11/Jellyfin.Api/Controllers/ItemsController.cs#L924-L925

Jellyswarrm only wires the **legacy** path to `get_items_from_all_servers` (which fans out and merges across servers). `/UserItems/Resume` has no matching route, so it hits the `proxy_handler` fallback and is forwarded to a single backend — the user only sees one server's resume items.

The Android TV client (jellyfin-sdk-kotlin) hits the new route unconditionally:

```kotlin
// jellyfin-sdk-kotlin — ItemsApi.kt, getResumeItems()  (v1.8.5)
val response = api.get<BaseItemDtoQueryResult>("/UserItems/Resume", pathParameters, queryParameters, data)
```
- https://github.com/jellyfin/jellyfin-sdk-kotlin/blob/v1.8.5/jellyfin-api/src/commonMain/kotlin-generated/org/jellyfin/sdk/api/operations/ItemsApi.kt

### Fix
Register `/UserItems/Resume` with the same federated handler, mirroring the existing `/UserViews` route. No path param is involved (userId is a query param, resolved from the auth session), which matches how `get_items_from_all_servers` is already used for `/UserViews`, `/Persons`, `/Artists`, and `/LiveTv/Channels`.

The other new-style federated routes (`/Items`, `/Items/Latest`, `/UserViews`) are already covered, so this is the only remaining resume gap.

### Testing
- `cargo check` passes cleanly with this change (rust 1.92.0, full workspace).
- The change mirrors the existing `/UserViews` route exactly, and `get_items_from_all_servers` is already used for several path-param-less federated routes (`/UserViews`, `/Persons`, `/Artists`, `/LiveTv/Channels`), so it carries no behavioral risk beyond routing.
- I have **not** yet exercised this end-to-end against a live multi-server instance — happy to do that or defer to your testing. The diagnosis itself came from tracing the route table against a real client that hits `/UserItems/Resume` (Jellyfin Android TV) and seeing it fall through to the single-server fallback.
