### PR TITLE
Fix audio HLS streaming, Proxy defaults, and Jellyfin 12 web client compatibility     

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Jellyswarrm is a reverse proxy that lets you combine multiple Jellyfin servers i
 
 * **QuickConnect** – Sign in on one device by approving the code from another authenticated device.
 * **Websocket Support** – Needed for real-time features like SyncPlay (not fully reliable yet).
-* **Audio Streaming** – May not function correctly (still untested in many cases).
+* **Audio Streaming** – Progressive and HLS audio paths are proxied like video.
 * **Automatic Bitrate Adjustment** – Stream quality based on network conditions isn’t supported yet.
 * **Media Management** – Features like adding or deleting media libraries through Jellyswarrm are not implemented yet.
 

--- a/crates/jellyswarrm-proxy/src/handlers/videos.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/videos.rs
@@ -9,18 +9,19 @@ use crate::{
     config::MediaStreamingMode,
     extractors::Preprocessed,
     proxy_headers::remove_hop_by_hop_headers,
-    request_preprocessing::{apply_to_request, remap_authorization},
+    request_preprocessing::{apply_to_request, remap_authorization, PreprocessedRequest},
     server_storage::Server,
     session_storage::PlaybackSession,
     user_authorization_service::AuthorizationSession,
     AppState,
 };
 
-fn extract_video_id(path: &str) -> Option<&str> {
+/// Extract the media item id from `/Videos/{id}/...` or `/Audio/{id}/...` paths.
+fn extract_stream_item_id(path: &str) -> Option<&str> {
     let mut segments = path.trim_matches('/').split('/');
 
     while let Some(segment) = segments.next() {
-        if segment.eq_ignore_ascii_case("Videos") {
+        if segment.eq_ignore_ascii_case("Videos") || segment.eq_ignore_ascii_case("Audio") {
             return segments.next().filter(|segment| !segment.is_empty());
         }
     }
@@ -82,7 +83,7 @@ async fn proxy_request(
     Ok(response)
 }
 
-async fn forward_video_request(
+async fn forward_media_request(
     state: &AppState,
     server: &Server,
     request: reqwest::Request,
@@ -114,110 +115,10 @@ fn session_for_server(
     })
 }
 
-//http://localhost:3000/Videos/82fe5aab-29ff-9630-05c2-da1a5a640428/82fe5aab29ff963005c2da1a5a640428/Attachments/5
-//http://localhost:3000/Videos/71bda5a4-267a-1a6c-49ce-8536d36628d8/71bda5a4267a1a6c49ce8536d36628d8/Subtitles/3/0/Stream.js?api_key=4543ddacf7544d258444677c680d81a5
-pub async fn get_video_resource(
-    State(state): State<AppState>,
-    Preprocessed(preprocessed): Preprocessed,
-) -> Result<Response, StatusCode> {
-    let original_request = &preprocessed.original_request;
-
-    let id = extract_video_id(original_request.url().path())
-        .ok_or(StatusCode::NOT_FOUND)?
-        .to_string();
-    let play_session_id = extract_play_session_id(original_request.url());
-    let play_session = if let Some(play_session_id) = play_session_id.as_deref() {
-        state
-            .play_sessions
-            .get_session_by_session_and_item_id(play_session_id, &id)
-            .await
-            .ok_or_else(|| {
-                error!(
-                    "No play session found for resource: {} and session: {}",
-                    id, play_session_id
-                );
-                StatusCode::NOT_FOUND
-            })?
-    } else {
-        let candidates = state.play_sessions.get_sessions_by_item_id(&id).await;
-        let user_id = preprocessed
-            .user
-            .as_ref()
-            .map(|user| user.id.as_str())
-            .or_else(|| {
-                preprocessed
-                    .session
-                    .as_ref()
-                    .map(|session| session.user_id.as_str())
-            });
-
-        match single_matching_play_session(candidates, user_id) {
-            Ok(play_session) => {
-                warn!(
-                    "Video resource {} arrived without play session id; using only matching active session {}",
-                    id, play_session.session_id
-                );
-                play_session
-            }
-            Err(count) => {
-                if state
-                    .media_storage
-                    .get_media_mapping_with_server(&id)
-                    .await
-                    .map_err(|e| {
-                        error!(
-                            "Failed to resolve media mapping for video resource {}: {}",
-                            id, e
-                        );
-                        StatusCode::INTERNAL_SERVER_ERROR
-                    })?
-                    .is_some()
-                {
-                    let server = preprocessed.server;
-                    if !state
-                        .server_storage
-                        .server_status(server.id)
-                        .await
-                        .is_healthy()
-                    {
-                        error!(
-                            "Server {} for video resource {} is not healthy",
-                            server.name, id
-                        );
-                        return Err(StatusCode::NOT_FOUND);
-                    }
-
-                    warn!(
-                        "Video resource {} arrived without play session id; routing by virtual media mapping",
-                        id
-                    );
-                    return forward_video_request(
-                        &state,
-                        &server,
-                        preprocessed.request,
-                        "video resource",
-                    )
-                    .await;
-                }
-
-                if count == 0 {
-                    error!(
-                        "No play session found for video resource without session id: {}",
-                        id
-                    );
-                } else {
-                    error!(
-                        "Ambiguous video resource {} without play session id matched {} active sessions",
-                        id, count
-                    );
-                }
-                return Err(StatusCode::NOT_FOUND);
-            }
-        }
-    };
-
-    let original_request = preprocessed.original_request;
-
+async fn resolve_play_session_server(
+    state: &AppState,
+    play_session: &PlaybackSession,
+) -> Result<Server, StatusCode> {
     let server = match state
         .server_storage
         .get_server_by_id(play_session.server_id)
@@ -256,6 +157,160 @@ pub async fn get_video_resource(
         return Err(StatusCode::NOT_FOUND);
     }
 
+    Ok(server)
+}
+
+async fn resolve_server_for_stream_item(
+    state: &AppState,
+    item_id: &str,
+    play_session_id: Option<&str>,
+    user_id: Option<&str>,
+    fallback_server: &Server,
+) -> Result<Server, StatusCode> {
+    if let Some(play_session_id) = play_session_id {
+        if let Some(play_session) = state
+            .play_sessions
+            .get_session_by_session_and_item_id(play_session_id, item_id)
+            .await
+        {
+            return resolve_play_session_server(state, &play_session).await;
+        }
+    }
+
+    let candidates = state.play_sessions.get_sessions_by_item_id(item_id).await;
+    if let Ok(play_session) = single_matching_play_session(candidates, user_id) {
+        return resolve_play_session_server(state, &play_session).await;
+    }
+
+    // Prefer the virtual media mapping when available; preprocessing already selected a
+    // server from the path/query id, so fall back to that.
+    let _ = state
+        .media_storage
+        .get_media_mapping_with_server(item_id)
+        .await
+        .map_err(|e| {
+            error!(
+                "Failed to resolve media mapping for stream item {}: {}",
+                item_id, e
+            );
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(fallback_server.clone())
+}
+
+async fn forward_resource_by_media_mapping(
+    state: &AppState,
+    preprocessed: PreprocessedRequest,
+    id: &str,
+    reason: &str,
+) -> Result<Response, StatusCode> {
+    let server = preprocessed.server;
+    if !state
+        .server_storage
+        .server_status(server.id)
+        .await
+        .is_healthy()
+    {
+        error!("Server {} for media resource {} is not healthy", server.name, id);
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    // Only fall back when we actually know this virtual id.
+    if state
+        .media_storage
+        .get_media_mapping_with_server(id)
+        .await
+        .map_err(|e| {
+            error!("Failed to resolve media mapping for media resource {}: {}", id, e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .is_none()
+    {
+        error!(
+            "No play session and no media mapping for media resource {} ({})",
+            id, reason
+        );
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    warn!(
+        "Media resource {} {}; routing by virtual media mapping via {}",
+        id, reason, server.name
+    );
+    forward_media_request(state, &server, preprocessed.request, "media resource").await
+}
+
+//http://localhost:3000/Videos/82fe5aab-29ff-9630-05c2-da1a5a640428/82fe5aab29ff963005c2da1a5a640428/Attachments/5
+//http://localhost:3000/Videos/71bda5a4-267a-1a6c-49ce-8536d36628d8/71bda5a4267a1a6c49ce8536d36628d8/Subtitles/3/0/Stream.js?api_key=...
+//http://localhost:3000/Audio/{id}/master.m3u8?MediaSourceId=...&PlaySessionId=...
+//http://localhost:3000/Audio/{id}/hls1/main/0.ts?...
+pub async fn get_video_resource(
+    State(state): State<AppState>,
+    Preprocessed(preprocessed): Preprocessed,
+) -> Result<Response, StatusCode> {
+    let original_request = &preprocessed.original_request;
+
+    let id = extract_stream_item_id(original_request.url().path())
+        .ok_or(StatusCode::NOT_FOUND)?
+        .to_string();
+    let play_session_id = extract_play_session_id(original_request.url());
+    let play_session = if let Some(play_session_id) = play_session_id.as_deref() {
+        // Audio /universal often uses a client-generated PlaySessionId we never track
+        // (no prior PlaybackInfo). Fall back to media mapping instead of hard 404.
+        match state
+            .play_sessions
+            .get_session_by_session_and_item_id(play_session_id, &id)
+            .await
+        {
+            Some(session) => session,
+            None => {
+                return forward_resource_by_media_mapping(
+                    &state,
+                    preprocessed,
+                    &id,
+                    &format!("unknown play session id {play_session_id}"),
+                )
+                .await;
+            }
+        }
+    } else {
+        let candidates = state.play_sessions.get_sessions_by_item_id(&id).await;
+        let user_id = preprocessed
+            .user
+            .as_ref()
+            .map(|user| user.id.as_str())
+            .or_else(|| {
+                preprocessed
+                    .session
+                    .as_ref()
+                    .map(|session| session.user_id.as_str())
+            });
+
+        match single_matching_play_session(candidates, user_id) {
+            Ok(play_session) => {
+                warn!(
+                    "Media resource {} arrived without play session id; using only matching active session {}",
+                    id, play_session.session_id
+                );
+                play_session
+            }
+            Err(count) => {
+                return forward_resource_by_media_mapping(
+                    &state,
+                    preprocessed,
+                    &id,
+                    &format!("no unique play session (matched {count})"),
+                )
+                .await;
+            }
+        }
+    };
+
+    let original_request = preprocessed.original_request;
+
+    let server = resolve_play_session_server(&state, &play_session).await?;
+
     info!(
         "Found play session for resource: {}, session: {}, server: {}",
         id, play_session.session_id, server.name
@@ -284,16 +339,85 @@ pub async fn get_video_resource(
     )
     .await;
 
-    forward_video_request(&state, &server, upstream_request, "HLS stream").await
+    forward_media_request(&state, &server, upstream_request, "media resource").await
 }
 
+/// Progressive and universal media streams under `/Videos/{id}/stream*` and
+/// `/Audio/{id}/stream*|/universal`.
+///
+/// Prefer play-session / media-mapping routing so multi-server setups send audio and video
+/// to the correct upstream even when preprocessing falls back to the "best" server.
 pub async fn get_stream(
     State(state): State<AppState>,
     Preprocessed(preprocessed): Preprocessed,
 ) -> Result<Response, StatusCode> {
-    let server = preprocessed.server;
-    let request = preprocessed.request;
-    forward_video_request(&state, &server, request, "media stream").await
+    let original_url = preprocessed.original_request.url().clone();
+    let item_id = extract_stream_item_id(original_url.path()).map(str::to_string);
+    let play_session_id = extract_play_session_id(&original_url);
+    let user_id = preprocessed
+        .user
+        .as_ref()
+        .map(|user| user.id.as_str())
+        .or_else(|| {
+            preprocessed
+                .session
+                .as_ref()
+                .map(|session| session.user_id.as_str())
+        });
+
+    let server = if let Some(item_id) = item_id.as_deref() {
+        resolve_server_for_stream_item(
+            &state,
+            item_id,
+            play_session_id.as_deref(),
+            user_id,
+            &preprocessed.server,
+        )
+        .await?
+    } else {
+        preprocessed.server.clone()
+    };
+
+    if !state
+        .server_storage
+        .server_status(server.id)
+        .await
+        .is_healthy()
+    {
+        error!("Server {} for media stream is not healthy", server.name);
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    // If play-session routing selected a different server than preprocessing, rebuild the
+    // upstream request against that server with the matching session credentials.
+    let request = if server.id != preprocessed.server.id {
+        let mut upstream_request = preprocessed.original_request;
+        let session = session_for_server(&preprocessed.sessions, &server).or_else(|| {
+            (preprocessed.server.id == server.id)
+                .then(|| preprocessed.session.clone())
+                .flatten()
+        });
+        let new_auth = remap_authorization(&preprocessed.auth, &session)
+            .await
+            .map_err(|e| {
+                error!("Failed to remap authorization for media stream: {}", e);
+                StatusCode::BAD_REQUEST
+            })?;
+        apply_to_request(
+            &mut upstream_request,
+            &server,
+            &session,
+            &new_auth,
+            &state,
+            preprocessed.access_scope.as_ref(),
+        )
+        .await;
+        upstream_request
+    } else {
+        preprocessed.request
+    };
+
+    forward_media_request(&state, &server, request, "media stream").await
 }
 
 #[cfg(test)]
@@ -308,6 +432,23 @@ mod tests {
             user_id: user_id.to_string(),
             server_id: ServerId::new(server_id),
         }
+    }
+
+    #[test]
+    fn extract_stream_item_id_from_videos_and_audio() {
+        assert_eq!(
+            extract_stream_item_id("/Videos/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/master.m3u8"),
+            Some("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        );
+        assert_eq!(
+            extract_stream_item_id("/Audio/11111111111111111111111111111111/universal"),
+            Some("11111111111111111111111111111111")
+        );
+        assert_eq!(
+            extract_stream_item_id("/Audio/11111111111111111111111111111111/hls1/main/0.ts"),
+            Some("11111111111111111111111111111111")
+        );
+        assert_eq!(extract_stream_item_id("/Items/abc/PlaybackInfo"), None);
     }
 
     #[test]

--- a/crates/jellyswarrm-proxy/src/handlers/videos.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/videos.rs
@@ -212,7 +212,10 @@ async fn forward_resource_by_media_mapping(
         .await
         .is_healthy()
     {
-        error!("Server {} for media resource {} is not healthy", server.name, id);
+        error!(
+            "Server {} for media resource {} is not healthy",
+            server.name, id
+        );
         return Err(StatusCode::NOT_FOUND);
     }
 
@@ -222,7 +225,10 @@ async fn forward_resource_by_media_mapping(
         .get_media_mapping_with_server(id)
         .await
         .map_err(|e| {
-            error!("Failed to resolve media mapping for media resource {}: {}", id, e);
+            error!(
+                "Failed to resolve media mapping for media resource {}: {}",
+                id, e
+            );
             StatusCode::INTERNAL_SERVER_ERROR
         })?
         .is_none()

--- a/crates/jellyswarrm-proxy/src/main.rs
+++ b/crates/jellyswarrm-proxy/src/main.rs
@@ -700,13 +700,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         get(handlers::videos::get_video_resource),
                     ),
             )
-            // Audio streaming routes
+            // Audio streaming routes — mirror Videos so progressive + HLS
+            // (master.m3u8 / main.m3u8 / hls1 segments) use the streaming client
+            // and play-session / media-mapping routing instead of the generic API proxy.
             .nest(
                 "/Audio",
                 Router::new()
                     .route("/{item_id}/universal", get(handlers::videos::get_stream))
                     .route("/{item_id}/stream", get(handlers::videos::get_stream))
-                    .route("/{item_id}/stream.{container}", get(handlers::videos::get_stream)),
+                    .route(
+                        "/{item_id}/stream.{container}",
+                        get(handlers::videos::get_stream),
+                    )
+                    .route(
+                        "/{stream_id}/{*path}",
+                        get(handlers::videos::get_video_resource),
+                    ),
             )
             // Persons
             .nest(


### PR DESCRIPTION
## Summary                                                                                                                                              
- Fix audio streaming by routing full Jellyfin `/Audio/...` surface (including HLS `master.m3u8` / `main.m3u8` / `hls1/...`) through the streaming proxy
and play-session routing, matching `/Videos/...`.                                                                                                       
- Low-risk performance/ops improvements: default new servers to **Proxy**, HLS absolute same-server URL rewrite, HTTP/2 on the media client, quieter    
hot-path logs, connection pool tuning.                                                                                                                  
- Fix jellyfin-web **"Update Required"** when System/Info advertised an empty Version (seen with Jellyfin **12.0** web client builds). Public +         
authenticated System/Info now report the embedded web client version.                                                                                   
                                                                                                                                                        
## Motivation                                                                                                                                           
Audio HLS previously fell through to the generic API proxy (full buffer + request timeouts), so music often failed while video worked. Empty `Version`  
also broke modern jellyfin-web (including 12.0-rc) against the proxy.                                                                                   
                                                                                                                                                        
## Test plan                                                                                                                                            
- [x] Progressive + HLS audio playback through Jellyswarrm (Proxy mode)                                                                                 
- [x] Multi-server: local Jellyfin + remote backend                                                                                                     
- [x] User mappings / library browse                                                                                                                    
- [x] jellyfin-web loads without "Update Required" (Version reported)                                                                                   
- [x] Video still works as before (regression)                                                                                                          
- [x] Seek / Range on a long audio track                                                                                                                
                                                                                                                                                        
## Notes                                                                                                                                                
- Prefer **Proxy** when clients cannot reach backend Jellyfin hosts directly.                                                                           
- README: audio streaming moved to the working features list.                                                                                           
