### PR TITLE
Fix Device::matches short-prefix collision for web clients

### DIFF
--- a/crates/jellyswarrm-proxy/src/user_authorization_service.rs
+++ b/crates/jellyswarrm-proxy/src/user_authorization_service.rs
@@ -126,7 +126,9 @@ impl Device {
                 return true;
             }
 
-            // Web clients derive device_id from base64(user-agent + "|" + timestamp).
+            // Web clients derive device_id from base64(user-agent + "|" + timestamp) — see
+            // generateDeviceId() in jellyfin-web:
+            // https://github.com/jellyfin/jellyfin-web/blob/1363b749b5e01202919f8a35a2caabdaca6a18e0/src/components/apphost.js#L125-L133
             // normalize_device() lowercases it, so every browser's device_id starts with
             // the lowercased base64 of "Mozilla/5.0 (" ("tw96awxs..."), making the 16-char
             // prefix fallback below collide across ALL web sessions of a user. Require an

--- a/crates/jellyswarrm-proxy/src/user_authorization_service.rs
+++ b/crates/jellyswarrm-proxy/src/user_authorization_service.rs
@@ -122,8 +122,23 @@ impl Device {
 
         // 1) Strict match when both sides have a known device id.
         if self_has_known_device_id && other_has_known_device_id {
-            return self_device_id == other_device_id
-                || short_self_device_id == short_other_device_id;
+            if self_device_id == other_device_id {
+                return true;
+            }
+
+            // Web clients derive device_id from base64(user-agent + "|" + timestamp).
+            // normalize_device() lowercases it, so every browser's device_id starts with
+            // the lowercased base64 of "Mozilla/5.0 (" ("tw96awxs..."), making the 16-char
+            // prefix fallback below collide across ALL web sessions of a user. Require an
+            // exact device_id match for those instead of falling back to the short prefix.
+            const WEB_DEVICE_ID_PREFIX: &str = "tw96awxs";
+            if self_device_id.starts_with(WEB_DEVICE_ID_PREFIX)
+                || other_device_id.starts_with(WEB_DEVICE_ID_PREFIX)
+            {
+                return false;
+            }
+
+            return short_self_device_id == short_other_device_id;
         }
 
         // 2) Fallback to device name only when at least one side has no usable device id.
@@ -1777,6 +1792,54 @@ mod tests {
             sessions5.len(),
             0,
             "Should not find any match when client and version differ"
+        );
+
+        // Test 6: Two distinct web (browser) device ids sharing the same 16-char base64
+        // prefix ("Mozilla/5.0 (") must NOT fall back to a prefix match - every browser's
+        // device_id starts with that prefix, so this used to collide across all of a
+        // user's web sessions and let requests reuse another session's stale token.
+        let web_device_stored = Device {
+            client: "Jellyfin Web".to_string(),
+            device: "Chrome".to_string(),
+            device_id:
+                "TW96aWxsYS81LjAgKFdpbmRvd3MgTlQgMTAuMCkgQ2hyb21lLzE0Ny4wfDE3ODM4NTg5NzQ1Mjc1"
+                    .to_string(),
+            version: "10.11.10".to_string(),
+        };
+        service
+            .store_authorization_session(
+                &user.id,
+                "http://localhost:8096",
+                &Authorization {
+                    client: web_device_stored.client.clone(),
+                    device: web_device_stored.device.clone(),
+                    device_id: web_device_stored.device_id.clone(),
+                    version: web_device_stored.version.clone(),
+                    token: None,
+                },
+                "jellyfin-token-web".to_string(),
+                "original-jellyfin-user-id".to_string(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let web_device_query = Device {
+            client: "Jellyfin Web".to_string(),
+            device: "Chrome Android".to_string(),
+            device_id:
+                "TW96aWxsYS81LjAgKExpbnV4OyBBbmRyb2lkIDEwKSBDaHJvbWUvMTUwLjB8MTc4MzQ0MTUzNjM2NQ=="
+                    .to_string(),
+            version: "10.11.10".to_string(),
+        };
+        let sessions6 = service
+            .get_user_sessions(&user.id, Some(web_device_query))
+            .await
+            .unwrap();
+        assert_eq!(
+            sessions6.len(),
+            0,
+            "Distinct web device ids sharing the base64 'Mozilla/5.0 (' prefix must not match"
         );
     }
 


### PR DESCRIPTION
Web clients' `device_id` all begin with the same 16-character lowercased-base64 prefix of `"Mozilla/5.0 ("` (`tw96awxs...`), which the existing short-prefix fallback in `Device::matches()` used for comparison. This meant any two web sessions belonging to the same user were treated as matching regardless of their actual `device_id`, letting the proxy reuse/overwrite another session's stored Jellyfin access token and causing repeated 401 "Invalid token" loops.

This requires an exact `device_id` match whenever either side's `device_id` starts with that web prefix. The short-prefix fallback still applies unchanged for non-web clients (e.g. Switchfin), so their existing behavior and tests are unaffected.

Added a regression test with two distinct web `device_id`s sharing the prefix, asserting they no longer match.