### PR TITLE
Fix empty System/Info Version causing jellyfin-web Update Required

### DIFF
--- a/crates/jellyswarrm-proxy/src/handlers/system.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/system.rs
@@ -7,6 +7,23 @@ use crate::{
     AppState,
 };
 
+fn reported_server_version() -> String {
+    // Jellyfin Web refuses to load when Version is empty/unknown ("Update Required").
+    // Always report the embedded web client's version so the UI stays compatible.
+    let version = JELLYFIN_UI_VERSION
+        .clone()
+        .unwrap_or_default()
+        .version
+        .trim()
+        .to_string();
+    if version.is_empty() || version.eq_ignore_ascii_case("unknown") {
+        // Fallback for test builds that skip ui-version.env generation.
+        "10.11.0".to_string()
+    } else {
+        version
+    }
+}
+
 pub async fn info_public(
     State(state): State<AppState>,
 ) -> Result<Json<crate::models::PublicServerInfo>, StatusCode> {
@@ -16,7 +33,7 @@ pub async fn info_public(
         id: cfg.server_id.clone(),
         server_name: cfg.server_name.clone(),
         local_address: cfg.public_address.clone(),
-        version: JELLYFIN_UI_VERSION.clone().unwrap_or_default().version,
+        version: reported_server_version(),
         product_name: "Jellyfin Server".to_string(),
         operating_system: std::env::consts::OS.to_string(),
         startup_wizard_completed: true,
@@ -40,6 +57,9 @@ pub async fn info(
             server_info.id = cfg.server_id.clone();
             server_info.server_name = "Jellyswarrm Proxy".to_string();
             server_info.local_address = cfg.public_address.clone();
+            // Keep Version aligned with the embedded jellyfin-web client. Leaving the
+            // upstream version can surface "Update Required" when backends differ.
+            server_info.version = Some(reported_server_version());
 
             Ok(Json(server_info))
         }


### PR DESCRIPTION
Report the embedded web client version for public and authenticated System/Info so clients do not treat the proxy as an outdated/unknown server when ui-version.env was incomplete.