### PR TITLE
Collapse duplicate content in merged libraries

### DIFF
--- a/crates/jellyswarrm-proxy/src/config.rs
+++ b/crates/jellyswarrm-proxy/src/config.rs
@@ -142,6 +142,10 @@ fn default_merge_libraries() -> bool {
     true
 }
 
+fn default_deduplicate_merged_content() -> bool {
+    true
+}
+
 mod base64_serde {
     use super::*;
     use serde::de::Error as DeError;
@@ -235,6 +239,11 @@ define_fallback_deserializer!(
     default_auto_create_users_on_login
 );
 define_fallback_deserializer!(deserialize_merge_libraries, bool, default_merge_libraries);
+define_fallback_deserializer!(
+    deserialize_deduplicate_merged_content,
+    bool,
+    default_deduplicate_merged_content
+);
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PreconfiguredServer {
@@ -318,6 +327,15 @@ pub struct AppConfig {
         deserialize_with = "deserialize_merge_libraries"
     )]
     pub merge_libraries: bool,
+
+    /// When a merged library contains the same title from more than one server,
+    /// collapse it to a single entry (the highest-priority server's copy) rather
+    /// than listing one row per server.
+    #[serde(
+        default = "default_deduplicate_merged_content",
+        deserialize_with = "deserialize_deduplicate_merged_content"
+    )]
+    pub deduplicate_merged_content: bool,
 }
 
 impl fmt::Debug for AppConfig {

--- a/crates/jellyswarrm-proxy/src/duplicate_handling.rs
+++ b/crates/jellyswarrm-proxy/src/duplicate_handling.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::{
     models::{enums::BaseItemKind, MediaItem},
     server_storage::Server,
+    virtual_library_service::compare_virtual_library_routes,
 };
 
 #[derive(Debug, Clone)]
@@ -11,7 +12,13 @@ pub struct TaggedMediaItem {
     pub server: Server,
 }
 
-pub fn label_duplicates(items: Vec<TaggedMediaItem>) -> Vec<MediaItem> {
+/// Reconcile items that federated servers reported for the same merged library.
+///
+/// When `deduplicate` is true, content that exists on more than one server is
+/// collapsed to a single entry (the highest-priority server's copy). When it is
+/// false, every copy is kept but disambiguated with a `[Server]` suffix so the
+/// duplicates remain distinguishable in the client.
+pub fn label_duplicates(items: Vec<TaggedMediaItem>, deduplicate: bool) -> Vec<MediaItem> {
     let mut group_indexes: HashMap<String, usize> = HashMap::new();
     let mut groups: Vec<Vec<TaggedMediaItem>> = Vec::new();
     for tagged in items {
@@ -24,15 +31,52 @@ pub fn label_duplicates(items: Vec<TaggedMediaItem>) -> Vec<MediaItem> {
         }
     }
 
-    groups.into_iter().flat_map(label_duplicate_group).collect()
+    groups
+        .into_iter()
+        .flat_map(|group| label_duplicate_group(group, deduplicate))
+        .collect()
 }
 
-fn label_duplicate_group(group: Vec<TaggedMediaItem>) -> Vec<MediaItem> {
+fn label_duplicate_group(group: Vec<TaggedMediaItem>, deduplicate: bool) -> Vec<MediaItem> {
+    // A single occurrence is passed through untouched.
     if group.len() == 1 {
         return group.into_iter().map(|tagged| tagged.item).collect();
     }
 
-    group.into_iter().map(item_with_server_suffix).collect()
+    if !deduplicate {
+        // Deduplication disabled: keep every copy but tag it with its server so
+        // the client can still tell the otherwise-identical rows apart.
+        return group.into_iter().map(item_with_server_suffix).collect();
+    }
+
+    // The same content lives on more than one server. Collapse it to a single
+    // entry so the merged library shows one row instead of one per server.
+    //
+    // The winner is chosen deterministically with the same ordering the merged
+    // library folders already use (highest server priority, then a stable
+    // tiebreak on server name/id) so content rows and library folders agree on
+    // which upstream a duplicate resolves to. Each item's Id is already a
+    // per-server virtual id, so the winner still routes to its own upstream for
+    // playback; the dropped duplicates' mappings simply go unused.
+    group
+        .into_iter()
+        .max_by(|left, right| {
+            compare_virtual_library_routes(
+                &left.server,
+                left.item.id.as_str(),
+                &right.server,
+                right.item.id.as_str(),
+            )
+        })
+        .map(|winner| vec![winner.item])
+        .unwrap_or_default()
+}
+
+fn item_with_server_suffix(mut tagged: TaggedMediaItem) -> MediaItem {
+    if let Some(name) = tagged.item.name.as_mut() {
+        *name = format!("{name} [{}]", tagged.server.name);
+    }
+    tagged.item
 }
 
 fn duplicate_key(item: &MediaItem) -> String {
@@ -56,13 +100,6 @@ fn duplicate_key(item: &MediaItem) -> String {
         })
         .unwrap_or_default();
     format!("content:title:{name}:{year}:{:?}", item.item_type)
-}
-
-fn item_with_server_suffix(mut tagged: TaggedMediaItem) -> MediaItem {
-    if let Some(name) = tagged.item.name.as_mut() {
-        *name = format!("{name} [{}]", tagged.server.name);
-    }
-    tagged.item
 }
 
 fn episode_duplicate_key(item: &MediaItem) -> String {
@@ -186,7 +223,7 @@ mod tests {
     }
 
     #[test]
-    fn duplicates_are_kept_and_labeled_with_their_server() {
+    fn duplicates_collapse_to_the_highest_priority_server() {
         let less: MediaItem = serde_json::from_value(serde_json::json!({
             "Id": "left",
             "Name": "Wistoria",
@@ -203,31 +240,72 @@ mod tests {
             "ProviderIds": { "Tmdb": "abc" }
         }))
         .unwrap();
-        let result = label_duplicates(vec![
-            TaggedMediaItem {
-                item: less,
-                server: tagged(1, 100, "x", "abc").server,
-            },
-            TaggedMediaItem {
-                item: more,
-                server: tagged(2, 50, "x", "abc").server,
-            },
-        ]);
+        // Deliberately list the lower-priority server first to prove the winner
+        // is chosen by priority, not encounter order.
+        let result = label_duplicates(
+            vec![
+                TaggedMediaItem {
+                    item: more,
+                    server: tagged(2, 50, "x", "abc").server,
+                },
+                TaggedMediaItem {
+                    item: less,
+                    server: tagged(1, 100, "x", "abc").server,
+                },
+            ],
+            true,
+        );
+
+        // One row survives, unlabeled, and it is the higher-priority server's copy.
         assert_eq!(
             result
                 .iter()
                 .filter_map(|item| item.name.as_deref())
                 .collect::<Vec<_>>(),
-            vec!["Wistoria [Server 1]", "Wistoria [Server 2]"]
+            vec!["Wistoria"]
+        );
+        assert_eq!(
+            result
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["left"]
         );
     }
 
     #[test]
+    fn equal_priority_duplicates_collapse_deterministically() {
+        // When priorities tie, selection must still be stable across runs and
+        // independent of input order (matches library-folder winner selection).
+        let first_order = label_duplicates(
+            vec![
+                tagged(1, 100, "Dune", "shared"),
+                tagged(2, 100, "Dune", "shared"),
+            ],
+            true,
+        );
+        let second_order = label_duplicates(
+            vec![
+                tagged(2, 100, "Dune", "shared"),
+                tagged(1, 100, "Dune", "shared"),
+            ],
+            true,
+        );
+
+        assert_eq!(first_order.len(), 1);
+        assert_eq!(second_order.len(), 1);
+        assert_eq!(first_order[0].id, second_order[0].id);
+    }
+
+    #[test]
     fn same_title_with_different_provider_ids_is_not_a_duplicate() {
-        let result = label_duplicates(vec![
-            tagged(1, 100, "Crash", "1996"),
-            tagged(2, 100, "Crash", "2004"),
-        ]);
+        let result = label_duplicates(
+            vec![
+                tagged(1, 100, "Crash", "1996"),
+                tagged(2, 100, "Crash", "2004"),
+            ],
+            true,
+        );
 
         assert_eq!(
             result
@@ -247,7 +325,7 @@ mod tests {
         remake.item.provider_ids = None;
         remake.item.production_year = Some(2011);
 
-        let result = label_duplicates(vec![original, remake]);
+        let result = label_duplicates(vec![original, remake], true);
 
         assert_eq!(
             result
@@ -259,20 +337,49 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_episodes_are_also_labeled_with_their_server() {
-        let mut first = tagged(1, 100, "Pilot", "same");
+    fn duplicate_episodes_also_collapse_to_a_single_entry() {
+        let mut first = tagged(2, 50, "Pilot", "same");
         first.item.item_type = BaseItemKind::Episode;
-        let mut second = tagged(2, 100, "Pilot", "same");
+        let mut second = tagged(1, 100, "Pilot", "same");
         second.item.item_type = BaseItemKind::Episode;
 
-        let result = label_duplicates(vec![first, second]);
+        let result = label_duplicates(vec![first, second], true);
+
+        // Collapses to the higher-priority server's episode, unlabeled.
+        assert_eq!(
+            result
+                .iter()
+                .filter_map(|item| item.name.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["Pilot"]
+        );
+        assert_eq!(
+            result
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["1-Pilot"]
+        );
+    }
+
+    #[test]
+    fn duplicates_are_kept_and_labeled_when_dedup_disabled() {
+        // With deduplication turned off we fall back to the previous behavior:
+        // keep every copy, disambiguated by server name.
+        let result = label_duplicates(
+            vec![
+                tagged(1, 100, "Wistoria", "abc"),
+                tagged(2, 50, "Wistoria", "abc"),
+            ],
+            false,
+        );
 
         assert_eq!(
             result
                 .iter()
                 .filter_map(|item| item.name.as_deref())
                 .collect::<Vec<_>>(),
-            vec!["Pilot [Server 1]", "Pilot [Server 2]"]
+            vec!["Wistoria [Server 1]", "Wistoria [Server 2]"]
         );
     }
 }

--- a/crates/jellyswarrm-proxy/src/handlers/federated.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/federated.rs
@@ -213,7 +213,8 @@ async fn get_virtual_library_items(
         })
         .collect();
 
-    let items = FederatedItems::from_tagged_items(tagged_items);
+    let deduplicate = state.deduplicate_merged_content_enabled().await;
+    let items = FederatedItems::from_tagged_items(tagged_items, deduplicate);
     let total_count =
         estimate_merged_library_total(items.len(), upstream_total_sum, all_fully_fetched);
 

--- a/crates/jellyswarrm-proxy/src/handlers/federated/postprocessing.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/federated/postprocessing.rs
@@ -116,8 +116,8 @@ impl FederatedItems {
         Self::new(interleave(responses))
     }
 
-    pub(super) fn from_tagged_items(items: Vec<TaggedMediaItem>) -> Self {
-        Self::new(label_duplicates(items))
+    pub(super) fn from_tagged_items(items: Vec<TaggedMediaItem>, deduplicate: bool) -> Self {
+        Self::new(label_duplicates(items, deduplicate))
     }
 
     pub(super) fn merge_interleaved(mut self, server_items: Vec<ServerItems>) -> Self {

--- a/crates/jellyswarrm-proxy/src/main.rs
+++ b/crates/jellyswarrm-proxy/src/main.rs
@@ -179,6 +179,10 @@ impl AppState {
         self.config.read().await.merge_libraries
     }
 
+    pub async fn deduplicate_merged_content_enabled(&self) -> bool {
+        self.config.read().await.deduplicate_merged_content
+    }
+
     pub async fn process_response_json(
         &self,
         payload: &mut serde_json::Value,

--- a/crates/jellyswarrm-proxy/src/ui/admin/libraries.rs
+++ b/crates/jellyswarrm-proxy/src/ui/admin/libraries.rs
@@ -28,6 +28,9 @@ pub struct LibrariesPageTemplate {
     pub merge_libraries: bool,
     pub has_merge_libraries_error: bool,
     pub merge_libraries_error: String,
+    pub deduplicate_merged_content: bool,
+    pub has_deduplicate_error: bool,
+    pub deduplicate_error: String,
     pub ui_route: String,
 }
 
@@ -37,6 +40,9 @@ struct MergeLibrariesControlTemplate {
     merge_libraries: bool,
     has_merge_libraries_error: bool,
     merge_libraries_error: String,
+    deduplicate_merged_content: bool,
+    has_deduplicate_error: bool,
+    deduplicate_error: String,
     ui_route: String,
 }
 
@@ -106,12 +112,22 @@ pub struct UpdateMergeLibrariesForm {
     pub merge_libraries: bool,
 }
 
+#[derive(Deserialize)]
+pub struct UpdateDeduplicateForm {
+    #[serde(default)]
+    pub deduplicate_merged_content: bool,
+}
+
 pub async fn libraries_page(State(state): State<AppState>) -> impl IntoResponse {
     let merge_libraries = state.merge_libraries_enabled().await;
+    let deduplicate_merged_content = state.deduplicate_merged_content_enabled().await;
     let template = LibrariesPageTemplate {
         merge_libraries,
         has_merge_libraries_error: false,
         merge_libraries_error: String::new(),
+        deduplicate_merged_content,
+        has_deduplicate_error: false,
+        deduplicate_error: String::new(),
         ui_route: state.get_ui_route().await,
     };
     match template.render() {
@@ -123,16 +139,19 @@ pub async fn libraries_page(State(state): State<AppState>) -> impl IntoResponse 
     }
 }
 
-fn render_merge_libraries_control(
-    merge_libraries: bool,
-    ui_route: String,
-    error_message: Option<&str>,
+async fn render_merge_libraries_control(
+    state: &AppState,
+    merge_error: Option<&str>,
+    deduplicate_error: Option<&str>,
 ) -> Response {
     let template = MergeLibrariesControlTemplate {
-        merge_libraries,
-        has_merge_libraries_error: error_message.is_some(),
-        merge_libraries_error: error_message.unwrap_or_default().to_string(),
-        ui_route,
+        merge_libraries: state.merge_libraries_enabled().await,
+        has_merge_libraries_error: merge_error.is_some(),
+        merge_libraries_error: merge_error.unwrap_or_default().to_string(),
+        deduplicate_merged_content: state.deduplicate_merged_content_enabled().await,
+        has_deduplicate_error: deduplicate_error.is_some(),
+        deduplicate_error: deduplicate_error.unwrap_or_default().to_string(),
+        ui_route: state.get_ui_route().await,
     };
     match template.render() {
         Ok(html) => Html(html).into_response(),
@@ -147,7 +166,6 @@ pub async fn update_merge_libraries(
     State(state): State<AppState>,
     Form(form): Form<UpdateMergeLibrariesForm>,
 ) -> Response {
-    let ui_route = state.get_ui_route().await;
     let save_result = {
         let mut config = state.config.write().await;
         let mut updated = config.clone();
@@ -162,15 +180,46 @@ pub async fn update_merge_libraries(
     };
 
     match save_result {
-        Ok(()) => render_merge_libraries_control(form.merge_libraries, ui_route, None),
+        Ok(()) => render_merge_libraries_control(&state, None, None).await,
         Err(error) => {
             error!("Failed to save automatic library merging setting: {error}");
-            let current_value = state.merge_libraries_enabled().await;
             render_merge_libraries_control(
-                current_value,
-                ui_route,
+                &state,
+                Some("Could not save this setting. The previous behavior is still active."),
+                None,
+            )
+            .await
+        }
+    }
+}
+
+pub async fn update_deduplicate_content(
+    State(state): State<AppState>,
+    Form(form): Form<UpdateDeduplicateForm>,
+) -> Response {
+    let save_result = {
+        let mut config = state.config.write().await;
+        let mut updated = config.clone();
+        updated.deduplicate_merged_content = form.deduplicate_merged_content;
+        match save_config(&updated) {
+            Ok(()) => {
+                *config = updated;
+                Ok(())
+            }
+            Err(error) => Err(error),
+        }
+    };
+
+    match save_result {
+        Ok(()) => render_merge_libraries_control(&state, None, None).await,
+        Err(error) => {
+            error!("Failed to save merged-content deduplication setting: {error}");
+            render_merge_libraries_control(
+                &state,
+                None,
                 Some("Could not save this setting. The previous behavior is still active."),
             )
+            .await
         }
     }
 }
@@ -658,6 +707,9 @@ mod tests {
             merge_libraries: enabled,
             has_merge_libraries_error: false,
             merge_libraries_error: String::new(),
+            deduplicate_merged_content: enabled,
+            has_deduplicate_error: false,
+            deduplicate_error: String::new(),
             ui_route: "admin".to_string(),
         }
         .render()
@@ -719,12 +771,38 @@ mod tests {
             merge_libraries: true,
             has_merge_libraries_error: false,
             merge_libraries_error: String::new(),
+            deduplicate_merged_content: true,
+            has_deduplicate_error: false,
+            deduplicate_error: String::new(),
             ui_route: "admin".to_string(),
         }
         .render()
         .unwrap();
 
         assert_eq!(html.matches("name=\"merge_libraries\"").count(), 1);
+    }
+
+    #[test]
+    fn merge_control_renders_deduplicate_toggle() {
+        let enabled = render_control(true);
+        assert!(enabled.contains("name=\"deduplicate_merged_content\""));
+        assert!(enabled.contains("hx-patch=\"/admin/libraries/deduplicate-content\""));
+        // Enabled state renders the checkbox as checked.
+        assert!(enabled.matches("checked").count() >= 1);
+
+        let disabled = MergeLibrariesControlTemplate {
+            merge_libraries: true,
+            has_merge_libraries_error: false,
+            merge_libraries_error: String::new(),
+            deduplicate_merged_content: false,
+            has_deduplicate_error: false,
+            deduplicate_error: String::new(),
+            ui_route: "admin".to_string(),
+        }
+        .render()
+        .unwrap();
+        // With dedup off and merge on, only the merge switch is checked.
+        assert_eq!(disabled.matches("checked").count(), 1);
     }
 
     #[test]

--- a/crates/jellyswarrm-proxy/src/ui/mod.rs
+++ b/crates/jellyswarrm-proxy/src/ui/mod.rs
@@ -141,6 +141,10 @@ pub fn ui_routes() -> axum::Router<AppState> {
             "/libraries/merge-libraries",
             axum::routing::patch(admin::libraries::update_merge_libraries),
         )
+        .route(
+            "/libraries/deduplicate-content",
+            axum::routing::patch(admin::libraries::update_deduplicate_content),
+        )
         .route("/libraries/groups", post(admin::libraries::create_group))
         .route(
             "/libraries/groups/{virtual_id}",

--- a/crates/jellyswarrm-proxy/src/ui/templates/admin/merge_libraries_control.html
+++ b/crates/jellyswarrm-proxy/src/ui/templates/admin/merge_libraries_control.html
@@ -23,4 +23,29 @@
     {% if has_merge_libraries_error %}
     <div class="alert alert-error" role="alert">{{ merge_libraries_error }}</div>
     {% endif %}
+
+    <div class="library-merge-mode-copy">
+        <h2>Deduplicate merged content</h2>
+        <p>When the same title appears on more than one server, show a single entry (the highest-priority server's copy) instead of one per server.</p>
+    </div>
+
+    <form class="library-merge-mode-form"
+          hx-patch="/{{ ui_route }}/libraries/deduplicate-content"
+          hx-target="#merge-libraries-control"
+          hx-swap="outerHTML"
+          hx-disabled-elt="this">
+        <label class="library-merge-mode-switch">
+            <input type="checkbox"
+                   role="switch"
+                   name="deduplicate_merged_content"
+                   value="true"
+                   hx-on:change="this.form.requestSubmit()"
+                   {% if deduplicate_merged_content %}checked{% endif %}>
+            <span>{% if deduplicate_merged_content %}Enabled{% else %}Disabled{% endif %}</span>
+        </label>
+    </form>
+
+    {% if has_deduplicate_error %}
+    <div class="alert alert-error" role="alert">{{ deduplicate_error }}</div>
+    {% endif %}
 </article>


### PR DESCRIPTION
## What this does
  
  This change collapses those duplicates so you see one entry per title. When there's a duplicate, it keeps the copy
  from the higher-priority server (the same priority you already set for servers), so the choice is consistent and
  predictable, never random. Playback is unaffected: each entry still points back to its own server, so the single row
  you see plays fine.
  
  There's a toggle on the Libraries admin page ("Deduplicate merged content"), on by default. Flip it off and you get
  the old one-row-per-server behavior back.
  
  ## Not included yet
  
  Search results still show both copies for now. Search runs across everything without the merged-library context that
  browsing has, so deduping it safely needs more care, that's being worked on as a follow-up and isn't part of this PR.
  
  ## Testing
  
  Unit tests cover collapse-to-highest-priority, deterministic tiebreak, episodes, and the toggle-off path. Full suite
  passes. Verified live on a two-server merged setup: single entries, plays correctly.
  
  Addresses #140 (the merged-library duplication part).