### PR TITLE
fix: remap virtual artist IDs in query parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ target
 
 /logs
 result
+
+/.worktrees

--- a/crates/jellyswarrm-proxy/src/processors/url_processor.rs
+++ b/crates/jellyswarrm-proxy/src/processors/url_processor.rs
@@ -42,6 +42,10 @@ pub static MEDIA_ID_QUERY_TAGS: &[&str] = &[
     "startItemId",
     "IDs",
     "PersonIds",
+    "ArtistIds",
+    "ContributingArtistIds",
+    "AlbumArtistIds",
+    "ExcludeArtistIds",
 ];
 
 pub static USER_ID_PATH_TAGS: &[&str] = &["Users"];
@@ -610,6 +614,58 @@ mod tests {
                 .find(|(key, _)| key.eq_ignore_ascii_case("tag"))
                 .map(|(_, value)| value.into_owned()),
             Some(mapping.virtual_media_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn artist_ids_query_param_is_remapped_to_real_upstream_id() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        MIGRATOR.run(&pool).await.unwrap();
+        let server_storage = ServerStorageService::new(pool.clone());
+        let server_id = server_storage
+            .add_server(
+                "Server",
+                "http://server.example",
+                100,
+                MediaStreamingMode::Redirect,
+            )
+            .await
+            .unwrap();
+        let server = server_storage
+            .get_server_by_id(server_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let media_storage = MediaStorageService::new(pool.clone());
+        let mapping = media_storage
+            .get_or_create_media_mapping("upstream-id", &server)
+            .await
+            .unwrap();
+        let virtual_libraries =
+            VirtualLibraryService::new(pool.clone(), server_storage.clone(), media_storage.clone());
+        let processor = UrlProcessor::new(DataContext {
+            user_authorization: Arc::new(UserAuthorizationService::new(pool)),
+            server_storage: Arc::new(server_storage),
+            media_storage: Arc::new(media_storage),
+            virtual_library_service: Arc::new(virtual_libraries),
+            play_sessions: Arc::new(SessionStorage::new()),
+            config: Arc::new(tokio::sync::RwLock::new(AppConfig::default())),
+        });
+        let mut url = url::Url::parse(&format!(
+            "http://localhost/Items?ContributingArtistIds={}",
+            mapping.virtual_media_id
+        ))
+        .unwrap();
+
+        processor
+            .client_to_server_url(&mut url, &None, None, Some(server_id))
+            .await;
+
+        assert_eq!(
+            url.query_pairs()
+                .find(|(key, _)| key.eq_ignore_ascii_case("ContributingArtistIds"))
+                .map(|(_, value)| value.into_owned()),
+            Some(mapping.original_media_id)
         );
     }
 }

--- a/crates/jellyswarrm-proxy/src/request_preprocessing.rs
+++ b/crates/jellyswarrm-proxy/src/request_preprocessing.rs
@@ -669,6 +669,19 @@ mod tests {
         assert!(matches_case_insensitive("ItemId", MEDIA_ID_QUERY_TAGS));
         assert!(matches_case_insensitive("AlbumId", MEDIA_ID_QUERY_TAGS));
         assert!(matches_case_insensitive("AlbumIds", MEDIA_ID_QUERY_TAGS));
+        assert!(matches_case_insensitive("ArtistIds", MEDIA_ID_QUERY_TAGS));
+        assert!(matches_case_insensitive(
+            "ContributingArtistIds",
+            MEDIA_ID_QUERY_TAGS
+        ));
+        assert!(matches_case_insensitive(
+            "AlbumArtistIds",
+            MEDIA_ID_QUERY_TAGS
+        ));
+        assert!(matches_case_insensitive(
+            "ExcludeArtistIds",
+            MEDIA_ID_QUERY_TAGS
+        ));
     }
 
     use crate::config::{AppConfig, MIGRATOR};


### PR DESCRIPTION
## Summary

Closes #170.

`MEDIA_ID_QUERY_TAGS` in `crates/jellyswarrm-proxy/src/processors/url_processor.rs` was missing the artist-related query tags (`ArtistIds`, `ContributingArtistIds`, `AlbumArtistIds`, `ExcludeArtistIds`). Client→server virtual-media-ID remapping already worked for `AlbumIds`/`PersonIds`/etc. through this allowlist, but artist browsing wasn't covered, so selecting an artist that lives only on a non-primary federated server sent an unmapped virtual ID upstream and returned no albums/songs.

- Added the four tags to the allowlist (single array, no other wiring needed, since existing consumers iterate it generically).
- Extended the existing const-coverage test to assert all four are present.
- Added a round-trip test verifying `client_to_server_url` rewrites a virtual ID carried in `ContributingArtistIds` to the real upstream ID.

## Test plan

- [x] `cargo test -p jellyswarrm-proxy`: 229 passed, 0 failed
- [x] `cargo clippy -p jellyswarrm-proxy --all-targets`: clean
- [x] `cargo fmt -p jellyswarrm-proxy`
- [x] Manual: verified live against a real two-server federated jellyswarrm setup. Built an image from this fix cherry-picked onto the currently deployed base, ran it in an isolated test container against the real backends, added a throwaway artist/album to the non-primary server only, and confirmed `GET /Items?ArtistIds=<virtual_id>` through jellyswarrm correctly remaps to the real upstream ID and returns that artist's tracks (previously would have returned nothing). Test data and container removed afterward.

## AI disclosure

This change was implemented with AI assistance (Claude Code), from a pre-written implementation plan reviewed and approved before coding started. Automated tests were run and pass, and the manual multi-server verification step above was performed live.

