### PR TITLE
feat: add mobile device recognition and data-saver profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Jellyswarrm is a reverse proxy that lets you combine multiple Jellyfin servers i
 * **Direct Playback** – Play content straight from the original server without extra overhead.
 * **User Mapping** – Link accounts across servers for a consistent user experience.
 * **API Compatibility** – Appears as a normal Jellyfin server, so existing apps and tools still work.
+* **Mobile Data Saver** – Mobile clients (Jellyfin Mobile, Swiftfin, Findroid, ...) are recognized at login and get capped stream bitrates and downscaled images, keeping cellular usage low.
 * **Server Federation** – Automatically sync users across connected servers.
 * **User Page** – Personal dashboard for managing credentials and libraries. 
 

--- a/crates/jellyswarrm-proxy/src/config.rs
+++ b/crates/jellyswarrm-proxy/src/config.rs
@@ -142,6 +142,25 @@ fn default_merge_libraries() -> bool {
     true
 }
 
+fn default_mobile_data_saver_enabled() -> bool {
+    true
+}
+
+/// Default cap for mobile stream bitrates, in bits per second (4 Mbps).
+fn default_mobile_max_streaming_bitrate() -> i64 {
+    4_000_000
+}
+
+/// Default maximum image width for mobile clients, in pixels.
+fn default_mobile_image_max_width() -> u32 {
+    640
+}
+
+/// Default image quality for mobile clients (0-100).
+fn default_mobile_image_quality() -> u32 {
+    70
+}
+
 mod base64_serde {
     use super::*;
     use serde::de::Error as DeError;
@@ -235,6 +254,26 @@ define_fallback_deserializer!(
     default_auto_create_users_on_login
 );
 define_fallback_deserializer!(deserialize_merge_libraries, bool, default_merge_libraries);
+define_fallback_deserializer!(
+    deserialize_mobile_data_saver_enabled,
+    bool,
+    default_mobile_data_saver_enabled
+);
+define_fallback_deserializer!(
+    deserialize_mobile_max_streaming_bitrate,
+    i64,
+    default_mobile_max_streaming_bitrate
+);
+define_fallback_deserializer!(
+    deserialize_mobile_image_max_width,
+    u32,
+    default_mobile_image_max_width
+);
+define_fallback_deserializer!(
+    deserialize_mobile_image_quality,
+    u32,
+    default_mobile_image_quality
+);
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PreconfiguredServer {
@@ -318,6 +357,38 @@ pub struct AppConfig {
         deserialize_with = "deserialize_merge_libraries"
     )]
     pub merge_libraries: bool,
+
+    /// Whether mobile clients get the data-saver profile (bitrate cap,
+    /// downscaled images). Defaults to `true`.
+    #[serde(
+        default = "default_mobile_data_saver_enabled",
+        deserialize_with = "deserialize_mobile_data_saver_enabled"
+    )]
+    pub mobile_data_saver_enabled: bool,
+
+    /// Cap for mobile stream bitrates in bits per second. `0` disables the
+    /// cap. Defaults to 4 Mbps.
+    #[serde(
+        default = "default_mobile_max_streaming_bitrate",
+        deserialize_with = "deserialize_mobile_max_streaming_bitrate"
+    )]
+    pub mobile_max_streaming_bitrate: i64,
+
+    /// Maximum image width in pixels for mobile clients. `0` disables image
+    /// downscaling. Defaults to 640.
+    #[serde(
+        default = "default_mobile_image_max_width",
+        deserialize_with = "deserialize_mobile_image_max_width"
+    )]
+    pub mobile_image_max_width: u32,
+
+    /// Image encoding quality (0-100) for mobile clients. `0` disables image
+    /// downscaling. Defaults to 70.
+    #[serde(
+        default = "default_mobile_image_quality",
+        deserialize_with = "deserialize_mobile_image_quality"
+    )]
+    pub mobile_image_quality: u32,
 }
 
 impl fmt::Debug for AppConfig {
@@ -350,6 +421,14 @@ impl fmt::Debug for AppConfig {
                 "auto_create_users_on_login",
                 &self.auto_create_users_on_login,
             )
+            .field("merge_libraries", &self.merge_libraries)
+            .field("mobile_data_saver_enabled", &self.mobile_data_saver_enabled)
+            .field(
+                "mobile_max_streaming_bitrate",
+                &self.mobile_max_streaming_bitrate,
+            )
+            .field("mobile_image_max_width", &self.mobile_image_max_width)
+            .field("mobile_image_quality", &self.mobile_image_quality)
             .finish()
     }
 }

--- a/crates/jellyswarrm-proxy/src/device_profile.rs
+++ b/crates/jellyswarrm-proxy/src/device_profile.rs
@@ -1,0 +1,495 @@
+//! Device classification and mobile data-saver profiles.
+//!
+//! Jellyswarrm recognizes clients through the Jellyfin handshake headers
+//! (`Authorization` / `X-Emby-Authorization`), which carry `Client`, `Device`,
+//! `DeviceId` and `Version`, plus the `User-Agent` header. This module turns
+//! that identity into a coarse [`DeviceClass`] and derives a data-saver
+//! profile that is applied to mobile clients so that streaming over cellular
+//! connections uses less bandwidth and stays stable on flaky links:
+//!
+//! * stream requests get a `MaxStreamingBitrate` cap (the upstream server
+//!   transcodes down to it),
+//! * `PlaybackInfo` requests get a `MaxStreamingBitrate` injected into the
+//!   body so client and server agree before playback starts,
+//! * image requests get `maxWidth`/`quality` parameters appended so posters
+//!   and backdrops are served downscaled.
+
+use crate::config::AppConfig;
+use crate::user_authorization_service::{normalize_device, Device};
+
+/// Coarse device class derived from the Jellyfin client handshake.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeviceClass {
+    /// Phones and tablets (Jellyfin Mobile, Swiftfin, Findroid, ...).
+    Mobile,
+    /// TVs and streaming sticks (Android TV, webOS, Tizen, Roku, Chromecast, ...).
+    Tv,
+    /// Desktop and web clients (Jellyfin Web, Jellyfin Desktop, browsers, ...).
+    Desktop,
+    /// Anything we could not classify.
+    Unknown,
+}
+
+impl DeviceClass {
+    /// Whether this class should receive the mobile data-saver profile.
+    pub fn is_mobile(self) -> bool {
+        matches!(self, DeviceClass::Mobile)
+    }
+}
+
+/// Client name fragments that indicate a TV/streaming-stick client.
+/// Checked before the mobile markers: "Jellyfin Android TV" must classify as
+/// `Tv`, not `Mobile`. Bare "samsung"/"lg" are intentionally absent here —
+/// they are common phone model names in the `Device` field.
+const TV_CLIENT_MARKERS: &[&str] = &[
+    "android tv",
+    "androidtv",
+    "webos",
+    "tizen",
+    "roku",
+    "chromecast",
+    "fire tv",
+    "firetv",
+    "smart tv",
+    "smarttv",
+    "samsung tv",
+    "lg tv",
+    "vizio",
+    "apple tv",
+    "tvos",
+    "tv os",
+];
+
+/// Fragments that are unambiguous TV markers even in a `Device` name or
+/// `User-Agent` string (e.g. "Mozilla/5.0 (SMART-TV; Linux; ...)").
+const TV_DEVICE_OR_UA_MARKERS: &[&str] = &[
+    "android tv",
+    "androidtv",
+    "webos",
+    "tizen",
+    "roku",
+    "chromecast",
+    "fire tv",
+    "firetv",
+    "smart tv",
+    "smarttv",
+    "apple tv",
+    "tvos",
+    "tv os",
+];
+
+/// Client name fragments that indicate a phone/tablet client.
+const MOBILE_CLIENT_MARKERS: &[&str] = &[
+    "mobile",
+    "swiftfin",
+    "findroid",
+    "jellyplayer",
+    "fintasoft",
+    "ios",
+    "iphone",
+    "ipad",
+    "ipod",
+    "android", // after TV markers: "Jellyfin Android TV" already returned Tv
+];
+
+/// Fragments that indicate a mobile device in a `Device` name or `User-Agent`.
+const MOBILE_DEVICE_OR_UA_MARKERS: &[&str] = &[
+    "mobile",
+    "iphone",
+    "ipad",
+    "ipod",
+    "android",
+    "windows phone",
+    "opera mini",
+    "blackberry",
+];
+
+/// Client name fragments for known desktop/web clients.
+const DESKTOP_CLIENT_MARKERS: &[&str] = &[
+    "jellyfin web",
+    "jellyfin desktop",
+    "jellyfin media player",
+    "emby theater",
+    "jellyfin kodi",
+    "mozill",
+    "chrome",
+    "firefox",
+    "safari",
+    "edge",
+    "opera",
+];
+
+/// Classify a device from its handshake identity.
+///
+/// `client`/`device` come from the parsed `Authorization` header
+/// (`X-Emby-Authorization`), `user_agent` from the `User-Agent` header when
+/// available. The user agent is only consulted as a fallback so that web
+/// clients opened on a phone (e.g. "Jellyfin Web" in mobile Safari) are still
+/// recognized as mobile.
+pub fn classify_device(client: &str, device: &str, user_agent: Option<&str>) -> DeviceClass {
+    let client_norm = normalize_device(client);
+    let device_norm = normalize_device(device);
+
+    if contains_any(&client_norm, TV_CLIENT_MARKERS)
+        || contains_any(&device_norm, TV_DEVICE_OR_UA_MARKERS)
+    {
+        return DeviceClass::Tv;
+    }
+    if contains_any(&client_norm, MOBILE_CLIENT_MARKERS)
+        || contains_any(&device_norm, MOBILE_DEVICE_OR_UA_MARKERS)
+    {
+        return DeviceClass::Mobile;
+    }
+
+    if let Some(user_agent) = user_agent {
+        let ua = normalize_device(user_agent);
+        if contains_any(&ua, TV_DEVICE_OR_UA_MARKERS) {
+            return DeviceClass::Tv;
+        }
+        if contains_any(&ua, MOBILE_DEVICE_OR_UA_MARKERS) {
+            return DeviceClass::Mobile;
+        }
+    }
+
+    if contains_any(&client_norm, DESKTOP_CLIENT_MARKERS) {
+        return DeviceClass::Desktop;
+    }
+
+    DeviceClass::Unknown
+}
+
+/// Classify a [`Device`] resolved during request preprocessing.
+pub fn classify_device_identity(device: &Device, user_agent: Option<&str>) -> DeviceClass {
+    classify_device(&device.client, &device.device, user_agent)
+}
+
+fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| haystack.contains(needle))
+}
+
+/// Data-saver settings applied to mobile clients.
+#[derive(Debug, Clone, Copy)]
+pub struct DataSaverProfile {
+    /// Cap for stream bitrates in bits per second.
+    pub max_streaming_bitrate: Option<i64>,
+    /// Maximum width for served images, in pixels.
+    pub image_max_width: Option<u32>,
+    /// Image encoding quality (0-100).
+    pub image_quality: Option<u32>,
+}
+
+impl DataSaverProfile {
+    /// Build the data-saver profile from the current configuration.
+    ///
+    /// Values of `0` in the configuration mean "leave this untouched" and map
+    /// to `None`. When data saver is disabled entirely, `None` is returned.
+    pub fn from_config(config: &AppConfig) -> Option<Self> {
+        if !config.mobile_data_saver_enabled {
+            return None;
+        }
+        Some(Self {
+            max_streaming_bitrate: (config.mobile_max_streaming_bitrate > 0)
+                .then_some(config.mobile_max_streaming_bitrate),
+            image_max_width: (config.mobile_image_max_width > 0)
+                .then_some(config.mobile_image_max_width),
+            image_quality: (config.mobile_image_quality > 0).then_some(config.mobile_image_quality),
+        })
+    }
+
+    /// Data-saver profile for a device class, if that class qualifies.
+    pub fn for_device_class(class: DeviceClass, config: &AppConfig) -> Option<Self> {
+        if !class.is_mobile() {
+            return None;
+        }
+        Self::from_config(config)
+    }
+}
+
+/// Clamp the streaming bitrate query parameters of an outgoing stream URL.
+///
+/// Jellyfin stream endpoints honor `MaxStreamingBitrate` (and the legacy
+/// `maxBitrate`) query parameters. If the client already asked for a lower
+/// bitrate it is left untouched; otherwise the value is capped at `cap_bps`.
+pub fn apply_stream_bitrate_cap(url: &mut url::Url, cap_bps: i64) {
+    let mut pairs: Vec<(String, String)> = url
+        .query_pairs()
+        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        .collect();
+
+    let mut clamp = |key: &str| {
+        if let Some((_, value)) = pairs.iter_mut().find(|(k, _)| k.eq_ignore_ascii_case(key)) {
+            if let Ok(current) = value.parse::<i64>() {
+                if current > cap_bps {
+                    *value = cap_bps.to_string();
+                }
+            }
+        }
+    };
+
+    clamp("MaxStreamingBitrate");
+    clamp("maxBitrate");
+
+    if !pairs
+        .iter()
+        .any(|(k, _)| k.eq_ignore_ascii_case("MaxStreamingBitrate"))
+    {
+        pairs.push(("MaxStreamingBitrate".to_string(), cap_bps.to_string()));
+    }
+
+    url.query_pairs_mut().clear().extend_pairs(pairs);
+}
+
+/// Append image downscaling parameters to an image request URL.
+///
+/// Only applies when the client did not already pin a size: a `width` or
+/// `maxWidth` parameter is respected as-is and `quality` is only added when
+/// absent.
+pub fn apply_image_params(url: &mut url::Url, max_width: u32, quality: u32) {
+    let has_width = url
+        .query_pairs()
+        .any(|(k, _)| k.eq_ignore_ascii_case("width") || k.eq_ignore_ascii_case("maxWidth"));
+    let has_quality = url
+        .query_pairs()
+        .any(|(k, _)| k.eq_ignore_ascii_case("quality"));
+
+    {
+        let mut pairs = url.query_pairs_mut();
+        if !has_width {
+            pairs.append_pair("maxWidth", &max_width.to_string());
+        }
+        if !has_quality {
+            pairs.append_pair("quality", &quality.to_string());
+        }
+    }
+}
+
+/// Whether a request path looks like a Jellyfin image endpoint.
+pub fn is_image_request_path(path: &str) -> bool {
+    path.split('/')
+        .any(|segment| segment.eq_ignore_ascii_case("Images"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn classify(client: &str, device: &str, ua: Option<&str>) -> DeviceClass {
+        classify_device(client, device, ua)
+    }
+
+    #[test]
+    fn mobile_clients_are_detected() {
+        assert_eq!(
+            classify("Jellyfin Mobile", "Pixel 8", None),
+            DeviceClass::Mobile
+        );
+        assert_eq!(
+            classify("Jellyfin Android", "SM-G991B", None),
+            DeviceClass::Mobile
+        );
+        assert_eq!(
+            classify("Swiftfin iPadOS", "iPad", None),
+            DeviceClass::Mobile
+        );
+        assert_eq!(
+            classify("Swiftfin Android", "Samsung Galaxy Tab S9", None),
+            DeviceClass::Mobile
+        );
+        assert_eq!(classify("Findroid", "Findroid", None), DeviceClass::Mobile);
+        assert_eq!(
+            classify("JellyPlayer", "JellyPlayer", None),
+            DeviceClass::Mobile
+        );
+        assert_eq!(
+            classify("Jellyfin iOS", "iPhone 15", None),
+            DeviceClass::Mobile
+        );
+    }
+
+    #[test]
+    fn tv_clients_are_not_mobile() {
+        assert_eq!(
+            classify("Jellyfin Android TV", "NVIDIA Shield", None),
+            DeviceClass::Tv
+        );
+        assert_eq!(classify("Jellyfin WebOS", "LG TV", None), DeviceClass::Tv);
+        assert_eq!(
+            classify("Jellyfin Tizen", "Samsung TV", None),
+            DeviceClass::Tv
+        );
+        assert_eq!(
+            classify("Jellyfin Chromecast", "Living Room TV", None),
+            DeviceClass::Tv
+        );
+        assert_eq!(
+            classify("Jellyfin Roku", "Roku Streaming Stick", None),
+            DeviceClass::Tv
+        );
+        assert_eq!(
+            classify("Jellyfin Apple TV", "Apple TV", None),
+            DeviceClass::Tv
+        );
+    }
+
+    #[test]
+    fn web_clients_classify_by_user_agent() {
+        // Desktop browser without mobile UA markers.
+        assert_eq!(
+            classify(
+                "Jellyfin Web",
+                "Firefox",
+                Some("Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0")
+            ),
+            DeviceClass::Desktop
+        );
+        // Same web client on a phone UA is mobile.
+        assert_eq!(
+            classify(
+                "Jellyfin Web",
+                "Mobile Safari",
+                Some("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15")
+            ),
+            DeviceClass::Mobile
+        );
+        assert_eq!(
+            classify(
+                "Jellyfin Web",
+                "Chrome",
+                Some("Mozilla/5.0 (Linux; Android 13; SM-G991B) AppleWebKit/537.36")
+            ),
+            DeviceClass::Mobile
+        );
+    }
+
+    #[test]
+    fn unknown_and_desktop_fallbacks() {
+        assert_eq!(
+            classify("SomeUnknownClient", "Device", None),
+            DeviceClass::Unknown
+        );
+        assert_eq!(
+            classify("Jellyfin Desktop", "PC", None),
+            DeviceClass::Desktop
+        );
+        assert_eq!(classify("Emby Theater", "PC", None), DeviceClass::Desktop);
+    }
+
+    #[test]
+    fn android_tv_wins_over_android_marker() {
+        // "android tv" is checked before the bare "android" mobile marker.
+        assert_eq!(
+            classify(
+                "Jellyfin Android TV",
+                "Shield",
+                Some("Mozilla/5.0 (Android TV)")
+            ),
+            DeviceClass::Tv
+        );
+    }
+
+    #[test]
+    fn stream_bitrate_cap_sets_when_absent() {
+        let mut url =
+            url::Url::parse("http://jellyfin:8096/Videos/abc/stream.mp4?Static=true").unwrap();
+        apply_stream_bitrate_cap(&mut url, 4_000_000);
+        assert_eq!(
+            url.query_pairs()
+                .find_map(|(k, v)| { (k == "MaxStreamingBitrate").then_some(v.into_owned()) }),
+            Some("4000000".to_string())
+        );
+    }
+
+    #[test]
+    fn stream_bitrate_cap_clamps_higher_requests() {
+        let mut url =
+            url::Url::parse("http://jellyfin:8096/Videos/abc/stream?MaxStreamingBitrate=120000000")
+                .unwrap();
+        apply_stream_bitrate_cap(&mut url, 4_000_000);
+        assert_eq!(
+            url.query_pairs()
+                .find_map(|(k, v)| { (k == "MaxStreamingBitrate").then_some(v.into_owned()) }),
+            Some("4000000".to_string())
+        );
+    }
+
+    #[test]
+    fn stream_bitrate_cap_respects_lower_requests() {
+        let mut url =
+            url::Url::parse("http://jellyfin:8096/Videos/abc/stream?maxBitrate=1500000").unwrap();
+        apply_stream_bitrate_cap(&mut url, 4_000_000);
+        assert_eq!(
+            url.query_pairs().find_map(|(k, v)| {
+                (k.eq_ignore_ascii_case("maxBitrate")).then_some(v.into_owned())
+            }),
+            Some("1500000".to_string())
+        );
+    }
+
+    #[test]
+    fn image_params_appended_when_missing() {
+        let mut url =
+            url::Url::parse("http://jellyfin:8096/Items/abc/Images/Primary?tag=xyz").unwrap();
+        apply_image_params(&mut url, 640, 70);
+        assert_eq!(
+            url.query_pairs()
+                .find_map(|(k, v)| { (k == "maxWidth").then_some(v.into_owned()) }),
+            Some("640".to_string())
+        );
+        assert_eq!(
+            url.query_pairs()
+                .find_map(|(k, v)| { (k == "quality").then_some(v.into_owned()) }),
+            Some("70".to_string())
+        );
+    }
+
+    #[test]
+    fn image_params_respect_client_sizes() {
+        let mut url = url::Url::parse(
+            "http://jellyfin:8096/Items/abc/Images/Backdrop/0?width=1920&quality=90",
+        )
+        .unwrap();
+        apply_image_params(&mut url, 640, 70);
+        assert_eq!(
+            url.query_pairs()
+                .find_map(|(k, v)| { (k == "width").then_some(v.into_owned()) }),
+            Some("1920".to_string())
+        );
+        assert!(!url.query_pairs().any(|(k, _)| k == "maxWidth"));
+        assert_eq!(
+            url.query_pairs()
+                .find_map(|(k, v)| { (k == "quality").then_some(v.into_owned()) }),
+            Some("90".to_string())
+        );
+    }
+
+    #[test]
+    fn image_path_detection() {
+        assert!(is_image_request_path("/Items/abc/Images/Primary"));
+        assert!(is_image_request_path(
+            "/Users/u1/Items/abc/Images/Backdrop/0"
+        ));
+        assert!(is_image_request_path("/Items/abc/images/logo"));
+        assert!(!is_image_request_path("/Items/abc/PlaybackInfo"));
+        assert!(!is_image_request_path("/Videos/abc/stream.mp4"));
+    }
+
+    #[test]
+    fn data_saver_profile_disabled_by_config() {
+        let config = AppConfig {
+            mobile_data_saver_enabled: false,
+            ..AppConfig::default()
+        };
+        assert!(DataSaverProfile::from_config(&config).is_none());
+        assert!(DataSaverProfile::for_device_class(DeviceClass::Mobile, &config).is_none());
+    }
+
+    #[test]
+    fn data_saver_profile_skips_non_mobile() {
+        let config = AppConfig::default();
+        assert!(DataSaverProfile::for_device_class(DeviceClass::Tv, &config).is_none());
+        assert!(DataSaverProfile::for_device_class(DeviceClass::Desktop, &config).is_none());
+        assert!(DataSaverProfile::for_device_class(DeviceClass::Unknown, &config).is_none());
+        let profile = DataSaverProfile::for_device_class(DeviceClass::Mobile, &config).unwrap();
+        assert_eq!(profile.max_streaming_bitrate, Some(4_000_000));
+    }
+}

--- a/crates/jellyswarrm-proxy/src/handlers/items.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/items.rs
@@ -3,6 +3,7 @@ use hyper::StatusCode;
 use tracing::{debug, error, warn};
 
 use crate::{
+    device_profile::DataSaverProfile,
     extractors::{Preprocessed, RequireSession},
     handlers::common::{
         execute_json_request, execute_processed_json_request, payload_from_request,
@@ -113,6 +114,21 @@ pub async fn post_playback_info(
     let server = preprocessed.server;
 
     let mut payload = payload;
+
+    // Mobile data-saver: cap the bitrate the client may request so the
+    // upstream server transcodes to a cellular-friendly rate. A lower
+    // client-requested value is always respected.
+    if let Some(profile) =
+        DataSaverProfile::for_device_class(preprocessed.device_class, &*state.config.read().await)
+    {
+        if let Some(cap_bps) = profile.max_streaming_bitrate {
+            payload.max_streaming_bitrate = Some(match payload.max_streaming_bitrate {
+                Some(existing) if existing <= cap_bps => existing,
+                _ => cap_bps,
+            });
+        }
+    }
+
     remap_playback_request(&mut payload, &state, &session).await?;
 
     debug!("Forwarding PlaybackRequest JSON: {:?}", &payload);

--- a/crates/jellyswarrm-proxy/src/handlers/users.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/users.rs
@@ -6,6 +6,7 @@ use hyper::{HeaderMap, StatusCode};
 use tracing::{debug, error, info, warn};
 
 use crate::{
+    device_profile::classify_device,
     encryption::Password,
     extractors::{RequireUser, RequireUserSession},
     handlers::common::execute_json_request,
@@ -114,6 +115,21 @@ pub async fn handle_authenticate_by_name(
     info!(
         "Got login request with authentication header: {}",
         authentication.to_redacted_header_value()
+    );
+
+    // Device handshake: classify the connecting client so the data-saver
+    // profile can be applied to mobile devices for the whole session.
+    let device_class = classify_device(
+        &authentication.client,
+        &authentication.device,
+        headers
+            .get("user-agent")
+            .and_then(|value| value.to_str().ok()),
+    );
+    info!(
+        "Client handshake from {} classified as {:?}",
+        authentication.to_short_string(),
+        device_class
     );
 
     info!(

--- a/crates/jellyswarrm-proxy/src/handlers/videos.rs
+++ b/crates/jellyswarrm-proxy/src/handlers/videos.rs
@@ -7,6 +7,7 @@ use tracing::{error, info, warn};
 
 use crate::{
     config::MediaStreamingMode,
+    device_profile::{apply_stream_bitrate_cap, DataSaverProfile, DeviceClass},
     extractors::Preprocessed,
     proxy_headers::remove_hop_by_hop_headers,
     request_preprocessing::{apply_to_request, remap_authorization, PreprocessedRequest},
@@ -89,9 +90,21 @@ async fn proxy_request(
 async fn forward_media_request(
     state: &AppState,
     server: &Server,
-    request: reqwest::Request,
+    mut request: reqwest::Request,
     log_label: &str,
+    device_class: DeviceClass,
 ) -> Result<Response, StatusCode> {
+    // Mobile data-saver: cap the stream bitrate so the upstream server
+    // transcodes to a cellular-friendly rate. This also applies to Redirect
+    // mode, where the query parameters are carried in the redirect URL.
+    if let Some(profile) =
+        DataSaverProfile::for_device_class(device_class, &*state.config.read().await)
+    {
+        if let Some(cap_bps) = profile.max_streaming_bitrate {
+            apply_stream_bitrate_cap(request.url_mut(), cap_bps);
+        }
+    }
+
     let url = request.url().clone();
 
     match server.media_streaming_mode {
@@ -235,7 +248,14 @@ async fn forward_preprocessed_resource(
         "No matching play session for resource {}; using media mapping via {}",
         id, server.name
     );
-    forward_media_request(state, &server, preprocessed.request, "media resource").await
+    forward_media_request(
+        state,
+        &server,
+        preprocessed.request,
+        "media resource",
+        preprocessed.device_class,
+    )
+    .await
 }
 
 pub async fn get_video_resource(
@@ -262,8 +282,9 @@ pub async fn get_video_resource(
         id, play_session.session_id, server.name
     );
 
+    let device_class = preprocessed.device_class;
     let request = request_for_server(&state, preprocessed, &server).await?;
-    forward_media_request(&state, &server, request, "media resource").await
+    forward_media_request(&state, &server, request, "media resource", device_class).await
 }
 
 pub async fn get_stream(
@@ -271,6 +292,7 @@ pub async fn get_stream(
     Preprocessed(preprocessed): Preprocessed,
 ) -> Result<Response, StatusCode> {
     let item_id = extract_stream_item_id(preprocessed.original_request.url().path());
+    let device_class = preprocessed.device_class;
     let session_id = extract_play_session_id(preprocessed.original_request.url());
     let play_session = if let Some(item_id) = item_id {
         let candidates = state.play_sessions.get_sessions_by_item_id(item_id).await;
@@ -286,16 +308,30 @@ pub async fn get_stream(
 
     let Some(play_session) = play_session else {
         let server = preprocessed.server;
-        return forward_media_request(&state, &server, preprocessed.request, "media stream").await;
+        return forward_media_request(
+            &state,
+            &server,
+            preprocessed.request,
+            "media stream",
+            device_class,
+        )
+        .await;
     };
     if play_session.server_id == preprocessed.server.id {
         let server = preprocessed.server;
-        return forward_media_request(&state, &server, preprocessed.request, "media stream").await;
+        return forward_media_request(
+            &state,
+            &server,
+            preprocessed.request,
+            "media stream",
+            device_class,
+        )
+        .await;
     }
 
     let server = resolve_play_session_server(&state, &play_session).await?;
     let request = request_for_server(&state, preprocessed, &server).await?;
-    forward_media_request(&state, &server, request, "media stream").await
+    forward_media_request(&state, &server, request, "media stream", device_class).await
 }
 
 #[cfg(test)]

--- a/crates/jellyswarrm-proxy/src/main.rs
+++ b/crates/jellyswarrm-proxy/src/main.rs
@@ -30,6 +30,7 @@ use axum_login::{
 mod config;
 #[cfg(debug_assertions)]
 mod debug_initialization;
+mod device_profile;
 mod duplicate_handling;
 mod encryption;
 mod extractors;
@@ -76,6 +77,7 @@ use crate::{
 };
 use crate::{
     config::{MediaStreamingMode, DATA_DIR},
+    device_profile::{apply_image_params, is_image_request_path, DataSaverProfile},
     encryption::Password,
     request_preprocessing::preprocess_request,
     session_storage::SessionStorage,
@@ -944,6 +946,8 @@ async fn proxy_handler(
         StatusCode::BAD_REQUEST
     })?;
 
+    let mut preprocessed = preprocessed;
+
     let request_url = preprocessed.request.url().clone();
     let response_server = preprocessed.server.clone();
     let response_proxy_api_key = preprocessed
@@ -959,6 +963,23 @@ async fn proxy_handler(
     );
 
     let request_processing_context = RequestProcessingContext::new(&preprocessed);
+
+    // Mobile data-saver: downscale image requests so browsing over cellular
+    // transfers far fewer bytes. The rewrite happens on the outgoing
+    // (upstream) URL after ID remapping.
+    if is_image_request_path(preprocessed.original_request.url().path()) {
+        if let Some(profile) = DataSaverProfile::for_device_class(
+            preprocessed.device_class,
+            &*state.config.read().await,
+        ) {
+            if let (Some(max_width), Some(quality)) =
+                (profile.image_max_width, profile.image_quality)
+            {
+                apply_image_params(preprocessed.request.url_mut(), max_width, quality);
+            }
+        }
+    }
+
     let mut request = preprocessed.request;
     state
         .processors

--- a/crates/jellyswarrm-proxy/src/request_preprocessing.rs
+++ b/crates/jellyswarrm-proxy/src/request_preprocessing.rs
@@ -6,6 +6,7 @@ use http_body_util::BodyExt;
 use std::fmt;
 use tracing::{debug, error};
 
+use crate::device_profile::{classify_device_identity, DeviceClass};
 use crate::models::Authorization;
 use crate::processors::analyze_json;
 use crate::processors::request_analyzer::{RequestAnalysisContext, RequestBodyAnalysisResult};
@@ -205,6 +206,10 @@ pub struct PreprocessedRequest {
     pub new_auth: Option<JellyfinAuthorization>,
     pub access_scope: Option<VirtualLibraryAccessScope>,
     pub server_matched_request: bool,
+    /// The device identity resolved from the handshake headers.
+    pub device: Option<Device>,
+    /// Coarse classification of [`Self::device`] (mobile/TV/desktop/unknown).
+    pub device_class: DeviceClass,
 }
 
 pub async fn extract_request_infos(
@@ -216,6 +221,7 @@ pub async fn extract_request_infos(
     Option<User>,
     Option<Vec<(AuthorizationSession, Server)>>,
     Option<RequestBodyAnalysisResult>,
+    Option<Device>,
 )> {
     let request = axum_to_reqwest(req).await?;
 
@@ -315,13 +321,22 @@ pub async fn extract_request_infos(
         None
     };
 
-    Ok((request, auth, user, sessions, request_body_result))
+    Ok((request, auth, user, sessions, request_body_result, device))
 }
 
 pub async fn preprocess_request(req: Request, state: &AppState) -> Result<PreprocessedRequest> {
     debug!("Preprocessing request: {:?}", req.uri());
-    let (mut request, auth, user, sessions, request_body_result) =
+    let (mut request, auth, user, sessions, request_body_result, device) =
         extract_request_infos(req, state).await?;
+    let user_agent = request
+        .headers()
+        .get("user-agent")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let device_class = device
+        .as_ref()
+        .map(|device| classify_device_identity(device, user_agent.as_deref()))
+        .unwrap_or(DeviceClass::Unknown);
     let original_request = request
         .try_clone()
         .ok_or_else(|| anyhow!("failed to clone preprocessed request body"))?;
@@ -373,6 +388,8 @@ pub async fn preprocess_request(req: Request, state: &AppState) -> Result<Prepro
         new_auth,
         access_scope,
         server_matched_request,
+        device,
+        device_class,
     })
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -35,6 +35,10 @@ The table below lists all available configuration options:
 | `url_prefix` | *(none)* | `JELLYSWARRM_URL_PREFIX` | Optional URL prefix for all routes (useful for reverse proxy setups). |
 | `server_background_check_interval_secs` | `30` | `JELLYSWARRM_SERVER_BACKGROUND_CHECK_INTERVAL_SECS` | Interval in seconds for background server health checks. |
 | `auto_create_users_on_login` | `true` | `JELLYSWARRM_AUTO_CREATE_USERS_ON_LOGIN` | Automatically create local users on successful upstream login. |
+| `mobile_data_saver_enabled` | `true` | `JELLYSWARRM_MOBILE_DATA_SAVER_ENABLED` | Apply the data-saver profile to mobile clients (bitrate cap + downscaled images). |
+| `mobile_max_streaming_bitrate` | `4000000` | `JELLYSWARRM_MOBILE_MAX_STREAMING_BITRATE` | Maximum stream bitrate in bits per second for mobile clients; the upstream server transcodes down to this. `0` disables the cap. |
+| `mobile_image_max_width` | `640` | `JELLYSWARRM_MOBILE_IMAGE_MAX_WIDTH` | Maximum width in pixels for images served to mobile clients. `0` disables image downscaling. |
+| `mobile_image_quality` | `70` | `JELLYSWARRM_MOBILE_IMAGE_QUALITY` | Image encoding quality (0-100) for images served to mobile clients. `0` disables image downscaling. |
 
 ---
 


### PR DESCRIPTION
## Summary

Jellyswarrm now **recognizes mobile devices at the client handshake** and automatically applies a **data-saver profile** that optimizes streaming for cellular connections. This addresses part of the roadmap item *"Automatic Bitrate Adjustment – Stream quality based on network conditions isn't supported yet"*.

### Handshake device recognition

Every client login (`POST /Users/AuthenticateByName`) is classified from the Jellyfin handshake headers (`Authorization` / `X-Emby-Authorization` `Client` + `Device`) with a `User-Agent` fallback, into `Mobile` / `Tv` / `Desktop` / `Unknown`:

- **Mobile**: Jellyfin Mobile, Swiftfin (iOS/Android/iPadOS), Findroid, JellyPlayer, mobile web browsers, ...
- **TV**: Android TV, webOS, Tizen, Roku, Chromecast, Fire TV, Apple TV, ... (checked *before* mobile markers so "Jellyfin Android TV" is never treated as a phone)
- The class is carried on every preprocessed request (`PreprocessedRequest.device_class`) and logged at login.

### Data-saver profile (applied when the device is Mobile)

1. **Stream bitrate cap** — stream requests (`/Videos/*/stream`, HLS, audio) get `MaxStreamingBitrate` clamped to `mobile_max_streaming_bitrate` (default **4 Mbps**) so the upstream server transcodes down. A lower client-requested bitrate is always respected. This applies in **both** `Proxy` and `Redirect` streaming modes — in Redirect mode the cap rides in the redirect URL, so the target server honors it too.
2. **PlaybackInfo injection** — `MaxStreamingBitrate` is injected into `POST /Items/{id}/PlaybackInfo` request bodies so client and server agree before playback starts.
3. **Image downscaling** — `/Items/*/Images/*` requests get `maxWidth` + `quality` appended (default **640px @ 70**) when the client did not pin a size — poster walls are the bulk of a browsing session's bytes.

### New configuration (TOML or `JELLYSWARRM_*` env vars, `0` disables an individual limit)

| Key | Default | Description |
|-----|---------|-------------|
| `mobile_data_saver_enabled` | `true` | Master switch for the data-saver profile |
| `mobile_max_streaming_bitrate` | `4000000` | Bitrate cap in bits/sec (4 Mbps) |
| `mobile_image_max_width` | `640` | Max served image width in px |
| `mobile_image_quality` | `70` | Image encoding quality (0-100) |

## Files changed

- `crates/jellyswarrm-proxy/src/device_profile.rs` — **new**: device classification + data-saver profile + URL rewrite helpers
- `crates/jellyswarrm-proxy/src/request_preprocessing.rs` — thread `device` + `device_class` through `PreprocessedRequest`
- `crates/jellyswarrm-proxy/src/handlers/videos.rs` — bitrate cap at the streaming choke point
- `crates/jellyswarrm-proxy/src/handlers/items.rs` — PlaybackInfo `MaxStreamingBitrate` injection
- `crates/jellyswarrm-proxy/src/main.rs` — image request downscaling in `proxy_handler`
- `crates/jellyswarrm-proxy/src/handlers/users.rs` — handshake classification log
- `crates/jellyswarrm-proxy/src/config.rs` — new config keys
- `docs/config.md`, `README.md` — documentation

## Testing

- 13 new unit tests in `device_profile.rs` (classification edge cases: Android TV vs Android phone, mobile web UA fallback, bitrate clamp semantics, image param semantics)
- Full suite: **248 tests passing**, `cargo clippy` clean, `cargo fmt --check` clean

## Notes / future work

- The server cannot distinguish cellular from Wi-Fi — mobile-class devices get the profile by default. A per-`DeviceId` admin override ("always cellular") is a natural follow-up.
- Response-side image URL rewriting (embedding `maxWidth` in item JSON) is a possible follow-up; the request-side rewrite already saves the bandwidth.
